### PR TITLE
Clamp entity move

### DIFF
--- a/src/duckling-tests/math/vector.spec.ts
+++ b/src/duckling-tests/math/vector.spec.ts
@@ -1,0 +1,61 @@
+import 'mocha';
+import {expect} from 'chai';
+import {vectorAdd, vectorSubtract, vectorRound} from '../../duckling/math';
+
+describe("vectorAdd", function() {
+    it("{1, 1} + {1, 1} = {2, 2}", function() {
+        expect(vectorAdd({x: 1, y: 1}, {x: 1, y: 1})).to.eql({x: 2, y: 2});
+    });
+
+    it("{1, 1} + {-1, 1} = {0, 2}", function() {
+        expect(vectorAdd({x: 1, y: 1}, {x: -1, y: 1})).to.eql({x: 0, y: 2});
+    });
+
+    it("{0, 0} + {-1, -1} = {-1, -1}", function() {
+        expect(vectorAdd({x: 0, y: 0}, {x: -1, y: -1})).to.eql({x: -1, y: -1});
+    });
+
+    it("{0, 0} + {0, 0} = {0, 0}", function() {
+        expect(vectorAdd({x: 0, y: 0}, {x: 0, y: 0})).to.eql({x: 0, y: 0});
+    });
+});
+
+describe("vectorSubtract", function() {
+    it("{1, 1} - {1, 1} = {0, 0}", function() {
+        expect(vectorSubtract({x: 1, y: 1}, {x: 1, y: 1})).to.eql({x: 0, y: 0});
+    });
+
+    it("{1, 1} - {-1, 1} = {2, 0}", function() {
+        expect(vectorSubtract({x: 1, y: 1}, {x: -1, y: 1})).to.eql({x: 2, y: 0});
+    });
+
+    it("{0, 0} - {-1, -1} = {1, 1}", function() {
+        expect(vectorSubtract({x: 0, y: 0}, {x: -1, y: -1})).to.eql({x: 1, y: 1});
+    });
+
+    it("{0, 0} - {0, 0} = {0, 0}", function() {
+        expect(vectorSubtract({x: 0, y: 0}, {x: 0, y: 0})).to.eql({x: 0, y: 0});
+    });
+});
+
+describe("vectorRound", function() {
+    it("{1.5, 1.5} = {2, 2}", function() {
+        expect(vectorRound({x: 1.5, y: 1.5})).to.eql({x: 2, y: 2});
+    });
+
+    it("{1.49, 1.49} = {1, 1}", function() {
+        expect(vectorRound({x: 1.49, y: 1.49})).to.eql({x: 1, y: 1});
+    });
+
+    it("{-1.5, -1.5} = {-1, -1}", function() {
+        expect(vectorRound({x: -1.5, y: -1.5})).to.eql({x: -1, y: -1});
+    });
+
+    it("{-1.49, -1.49} = {-1, -1}", function() {
+        expect(vectorRound({x: -1.49, y: -1.49})).to.eql({x: -1, y: -1});
+    });
+
+    it("{1, 1} = {1, 1}", function() {
+        expect(vectorRound({x: 1, y: 1})).to.eql({x: 1, y: 1});
+    });
+});

--- a/src/duckling/canvas/canvas.component.ts
+++ b/src/duckling/canvas/canvas.component.ts
@@ -22,7 +22,7 @@ import {
 } from 'pixi.js';
 
 import {Vector} from '../math';
-import {isMouseButtonPressed, MouseButton, WindowService} from '../util';
+import {isMouseButtonPressed, MouseButton, WindowService, KeyboardCodeLibrary} from '../util';
 
 import {ZOOM_LEVELS, DEFAULT_ZOOM_LEVEL} from './_toolbars/canvas-scale.component';
 import {drawRectangle} from './drawing/util';
@@ -129,18 +129,8 @@ export class CanvasComponent implements OnChanges, OnDestroy, AfterViewInit {
 
         this.canvasContainerDiv.nativeElement.parentElement.onwheel = (event : WheelEvent) => this.onScroll(event);
         this.canvasContainerDiv.nativeElement.parentElement.onmousemove = (event : MouseEvent) => event.preventDefault();
-        this.canvasContainerDiv.nativeElement.parentElement.onkeydown = (event : KeyboardEvent) => this._onKeyEvent(event);
-        this.canvasContainerDiv.nativeElement.parentElement.onkeyup = (event : KeyboardEvent) => this._onKeyEvent(event);
-    }
-
-    private _onKeyEvent(event : KeyboardEvent) {
-        if (this._isSpacebar(event)) {
-            event.preventDefault();
-        }
-    }
-
-    private _isSpacebar(event : KeyboardEvent) {
-        return event.keyCode === 32;
+        this.canvasContainerDiv.nativeElement.parentElement.onkeyup = (event : KeyboardEvent) => this.onKeyUp(event);
+        this.canvasContainerDiv.nativeElement.parentElement.onkeydown = (event : KeyboardEvent) => this.onKeyDown(event);
     }
 
     ngOnChanges(changes : {stageDimensions?:SimpleChange, scale?:SimpleChange}) {
@@ -200,6 +190,21 @@ export class CanvasComponent implements OnChanges, OnDestroy, AfterViewInit {
 
     onPaste(event : ClipboardEvent) {
         this.elementPaste.emit(this._stageCoordsFromCanvasCoords(this._mouseLocation));
+    }
+
+    onKeyDown(event : KeyboardEvent) {
+        if (this._isPreventedKey(event.keyCode)) {
+            event.preventDefault();
+        }
+        if (this.tool) {
+            this.tool.onKeyDown(this._createCanvasKeyEvent(event));
+        }
+    }
+
+    onKeyUp(event : KeyboardEvent) {
+        if (this.tool) {
+            this.tool.onKeyUp(this._createCanvasKeyEvent(event));
+        }
     }
 
     onMouseDown(event : MouseEvent) {
@@ -363,5 +368,25 @@ export class CanvasComponent implements OnChanges, OnDestroy, AfterViewInit {
             stageCoords: this._stageCoordsFromCanvasCoords(canvasCoords),
             canvas: this
         }
+    }
+
+    private _createCanvasKeyEvent(event : KeyboardEvent) : CanvasKeyEvent {
+        let canvasCoords = this._mouseLocation;
+        return {
+            keyCode: event.keyCode,
+            canvasCoords: canvasCoords,
+            stageCoords: this.stageCoordsFromCanvasCoords(canvasCoords),
+            canvas: this
+        }
+    }
+
+    private _isPreventedKey(keyCode : number) {
+        return (
+            KeyboardCodeLibrary.isSpacebar(keyCode) ||
+            KeyboardCodeLibrary.isUp(keyCode) ||
+            KeyboardCodeLibrary.isRight(keyCode) ||
+            KeyboardCodeLibrary.isDown(keyCode) ||
+            KeyboardCodeLibrary.isLeft(keyCode)
+        );
     }
 }

--- a/src/duckling/canvas/canvas.component.ts
+++ b/src/duckling/canvas/canvas.component.ts
@@ -375,7 +375,7 @@ export class CanvasComponent implements OnChanges, OnDestroy, AfterViewInit {
         return {
             keyCode: event.keyCode,
             canvasCoords: canvasCoords,
-            stageCoords: this.stageCoordsFromCanvasCoords(canvasCoords),
+            stageCoords: this._stageCoordsFromCanvasCoords(canvasCoords),
             canvas: this
         }
     }

--- a/src/duckling/canvas/canvas.component.ts
+++ b/src/duckling/canvas/canvas.component.ts
@@ -22,7 +22,7 @@ import {
 } from 'pixi.js';
 
 import {Vector} from '../math';
-import {isMouseButtonPressed, MouseButton, WindowService, KeyboardCodeLibrary} from '../util';
+import {isMouseButtonPressed, MouseButton, WindowService, KeyboardCode} from '../util';
 
 import {ZOOM_LEVELS, DEFAULT_ZOOM_LEVEL} from './_toolbars/canvas-scale.component';
 import {drawRectangle} from './drawing/util';
@@ -382,11 +382,11 @@ export class CanvasComponent implements OnChanges, OnDestroy, AfterViewInit {
 
     private _isPreventedKey(keyCode : number) {
         return (
-            KeyboardCodeLibrary.isSpacebar(keyCode) ||
-            KeyboardCodeLibrary.isUp(keyCode) ||
-            KeyboardCodeLibrary.isRight(keyCode) ||
-            KeyboardCodeLibrary.isDown(keyCode) ||
-            KeyboardCodeLibrary.isLeft(keyCode)
+            keyCode === KeyboardCode.SPACEBAR ||
+            keyCode === KeyboardCode.UP ||
+            keyCode === KeyboardCode.RIGHT ||
+            keyCode === KeyboardCode.DOWN ||
+            keyCode === KeyboardCode.LEFT
         );
     }
 }

--- a/src/duckling/canvas/tools/base-tool.ts
+++ b/src/duckling/canvas/tools/base-tool.ts
@@ -18,6 +18,12 @@ export class BaseTool {
     onStageMove(event : CanvasMouseEvent) {
     }
 
+    onKeyDown(event : CanvasKeyEvent) {
+    }
+
+    onKeyUp(event : CanvasKeyEvent) {
+    }
+
     onLeaveStage() {
     }
 

--- a/src/duckling/canvas/tools/bimodal-tool.ts
+++ b/src/duckling/canvas/tools/bimodal-tool.ts
@@ -34,6 +34,14 @@ export class BimodalTool extends BaseTool {
         this._selectedTool.onStageUp(event);
     }
 
+    onKeyDown(event : CanvasKeyEvent) {
+        this._selectedTool.onKeyDown(event);
+    }
+
+    onKeyUp(event : CanvasKeyEvent) {
+        this._selectedTool.onKeyUp(event);
+    }
+
     onLeaveStage() {
         this._selectedTool.onLeaveStage();
     }

--- a/src/duckling/canvas/tools/entity-move-tool.ts
+++ b/src/duckling/canvas/tools/entity-move-tool.ts
@@ -12,11 +12,12 @@ import {
 import {Vector} from '../../math';
 import {newMergeKey} from '../../state';
 import {SelectionService} from '../../selection';
+import {KeyboardCodeLibrary} from '../../util';
 import {getPosition} from '../../game/position/position-attribute';
 import {drawRectangle} from '../drawing';
 
 
-import {BaseTool, CanvasMouseEvent} from './base-tool';
+import {BaseTool, CanvasMouseEvent, CanvasKeyEvent} from './base-tool';
 
 @Injectable()
 export class EntityMoveTool extends BaseTool {
@@ -53,12 +54,32 @@ export class EntityMoveTool extends BaseTool {
             let nextCoords : Vector = event.stageCoords;
             nextCoords.x += this._selectOffsetCoords.x;
             nextCoords.y += this._selectOffsetCoords.y;
+            nextCoords.x = Math.round(nextCoords.x);
+            nextCoords.y = Math.round(nextCoords.y);
             this._entityPositionSetService.setPosition(this._selection, nextCoords, this._mergeKey);
         }
     }
 
     onStageUp(event : CanvasMouseEvent) {
         this._cancel();
+    }
+
+    onKeyDown(event : CanvasKeyEvent) {
+        if (this._selectionService.selection.value.entity) {
+            let oldPosition = getPosition(this._selectionService.selection.value.entity).position;
+            let adjustment = this._keyEventToPositionAdjustment(event.keyCode);
+            let newPosition = {
+                x: oldPosition.x + adjustment.x,
+                y: oldPosition.y + adjustment.y,
+            };
+            this._entityPositionSetService.setPosition(this._selectionService.selection.value.selectedEntity, newPosition, this._mergeKey);
+        }
+    }
+
+    onKeyUp(event : CanvasKeyEvent) {
+        if (this._selectionService.selection.value.entity && this._isMovementKey(event.keyCode)) {
+            this._mergeKey = newMergeKey();
+        }
     }
 
     onLeaveStage() {
@@ -100,5 +121,28 @@ export class EntityMoveTool extends BaseTool {
             drawRectangle(box.position, box.dimension, graphics);
         }
         return graphics;
+    }
+
+    private _keyEventToPositionAdjustment(keyCode : number) : Vector {
+        let adjustment : Vector = {x: 0, y: 0};
+        if (KeyboardCodeLibrary.isUp(keyCode)) {
+            adjustment.y = -1;
+        } else if (KeyboardCodeLibrary.isRight(keyCode)) {
+            adjustment.x = 1;
+        } else if (KeyboardCodeLibrary.isDown(keyCode)) {
+            adjustment.y = 1;
+        } else if (KeyboardCodeLibrary.isLeft(keyCode)) {
+            adjustment.x = -1;
+        }
+        return adjustment;
+    }
+
+    private _isMovementKey(keyCode : number) : boolean {
+        return (
+            KeyboardCodeLibrary.isUp(keyCode) ||
+            KeyboardCodeLibrary.isRight(keyCode) ||
+            KeyboardCodeLibrary.isDown(keyCode) ||
+            KeyboardCodeLibrary.isLeft(keyCode)
+        );
     }
 }

--- a/src/duckling/math/vector.ts
+++ b/src/duckling/math/vector.ts
@@ -2,3 +2,38 @@ export interface Vector {
     x : number,
     y : number
 }
+
+/**
+ * Add two vectors together
+ * @param  vectorA First vector to add
+ * @param  vectorB Second vector to add
+ * @return Resulting vector from the addition
+ */
+export function vectorAdd(vectorA : Vector, vectorB : Vector) : Vector {
+    return {
+        x: vectorA.x + vectorB.x,
+        y: vectorA.y + vectorB.y,
+    }
+}
+
+/**
+ * Subtract two vectors
+ * @param  vectorA First vector to subtract
+ * @param  vectorB Second vector to subtract
+ * @return Resulting vector from the subtraction
+ */
+export function vectorSubtract(vectorA : Vector, vectorB : Vector) : Vector {
+    return vectorAdd(vectorA, {x: -vectorB.x, y: -vectorB.y});
+}
+
+/**
+ * Round a vector to the nearest integer
+ * @param  vector Vector to round
+ * @return Resulting rounded vector
+ */
+export function vectorRound(vector : Vector) : Vector {
+    return {
+        x: Math.round(vector.x),
+        y: Math.round(vector.y)
+    }
+}

--- a/src/duckling/selection/copy-paste.service.ts
+++ b/src/duckling/selection/copy-paste.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
 
 import {Action, StoreService, newMergeKey} from '../state';
-import {Vector} from '../math';
+import {Vector, vectorRound} from '../math';
 import {Entity, EntitySystemService, EntityPositionSetService, EntityKey} from '../entitysystem';
 import {SelectionService} from './selection.service';
 
@@ -32,9 +32,7 @@ export class CopyPasteService {
         if (clipboardEntity) {
             let mergeKey = newMergeKey();
             let entityKey = this._entitySystem.addNewEntity(clipboardEntity, mergeKey);
-            position.x = Math.round(position.x);
-            position.y = Math.round(position.y);
-            this._setPosition.setPosition(entityKey, position, mergeKey);
+            this._setPosition.setPosition(entityKey, vectorRound(position), mergeKey);
             return entityKey;
         } else {
             return null;

--- a/src/duckling/selection/copy-paste.service.ts
+++ b/src/duckling/selection/copy-paste.service.ts
@@ -32,6 +32,8 @@ export class CopyPasteService {
         if (clipboardEntity) {
             let mergeKey = newMergeKey();
             let entityKey = this._entitySystem.addNewEntity(clipboardEntity, mergeKey);
+            position.x = Math.round(position.x);
+            position.y = Math.round(position.y);
             this._setPosition.setPosition(entityKey, position, mergeKey);
             return entityKey;
         } else {

--- a/src/duckling/util/keyboard.service.ts
+++ b/src/duckling/util/keyboard.service.ts
@@ -32,3 +32,29 @@ export class KeyboardService implements OnDestroy {
         this._heldKeys[event.keyCode] = false;
     }
 }
+
+
+/**
+ * Lookup functions for keyboard key codes
+ */
+export class KeyboardCodeLibrary {
+    static isSpacebar(keyCode : number) : boolean {
+        return keyCode === 32;
+    }
+
+    static isUp(keyCode : number) : boolean {
+        return keyCode === 38;
+    }
+
+    static isRight(keyCode : number) : boolean {
+        return keyCode === 39;
+    }
+
+    static isDown(keyCode : number) : boolean {
+        return keyCode === 40;
+    }
+
+    static isLeft(keyCode : number) : boolean {
+        return keyCode === 37;
+    }
+}

--- a/src/duckling/util/keyboard.service.ts
+++ b/src/duckling/util/keyboard.service.ts
@@ -35,26 +35,12 @@ export class KeyboardService implements OnDestroy {
 
 
 /**
- * Lookup functions for keyboard key codes
+ * Lookup for keyboard codes
  */
-export class KeyboardCodeLibrary {
-    static isSpacebar(keyCode : number) : boolean {
-        return keyCode === 32;
-    }
-
-    static isUp(keyCode : number) : boolean {
-        return keyCode === 38;
-    }
-
-    static isRight(keyCode : number) : boolean {
-        return keyCode === 39;
-    }
-
-    static isDown(keyCode : number) : boolean {
-        return keyCode === 40;
-    }
-
-    static isLeft(keyCode : number) : boolean {
-        return keyCode === 37;
-    }
+export const KeyboardCode = {
+    SPACEBAR: 32,
+    UP: 38,
+    RIGHT: 39,
+    DOWN: 40,
+    LEFT: 37
 }


### PR DESCRIPTION
Resolves #154 
- Clamps the entity move tool to only move in integer amounts
- Allow the usage of keyboard arrow keys to have micro adjustments to the selected entity's position
