### PR TITLE
always use unix style folder separator in asset references

### DIFF
--- a/src/duckling/project/browse-asset.component.ts
+++ b/src/duckling/project/browse-asset.component.ts
@@ -73,6 +73,9 @@ export class BrowseAssetComponent {
             return;
         }
         let splitAssetKey = file.split(homeResourceString + this._path.folderSeparator)[1].replace(/\.[^/.]+$/, "");
+        if (this._path.folderSeparator === "\\") {
+            splitAssetKey = splitAssetKey.replace(/\\/g, "/");
+        }
         this.filePicked.emit(splitAssetKey);
     }
 


### PR DESCRIPTION
Resolves #191 