### PR TITLE
Avoid mocha typings change

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/chai-spies": "0.0.0",
-    "@types/mocha": "^2.2.33",
+    "@types/mocha": "2.2.33",
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "concurrently": "^3.1.0",


### PR DESCRIPTION
A recent mocha typings change caused the this to have a type other than any. This breaks a lot of our unit tests.