### PR TITLE
Added styling to prevent the map select popup from becoming too large

### DIFF
--- a/src/duckling/project/map-select.component.scss
+++ b/src/duckling/project/map-select.component.scss
@@ -1,0 +1,4 @@
+.existing-map-list {
+    max-height: 60%;
+    overflow-y: auto;
+}

--- a/src/duckling/project/map-select.component.scss
+++ b/src/duckling/project/map-select.component.scss
@@ -1,4 +1,4 @@
-.existing-map-list {
+md-nav-list {
     max-height: 60%;
     overflow-y: auto;
 }

--- a/src/duckling/project/map-select.component.ts
+++ b/src/duckling/project/map-select.component.ts
@@ -18,8 +18,7 @@ import {openDialog} from '../util/md-dialog';
         </div>
         <div *ngIf="listLoaded">
             <dk-section headerText="Select an Existing Map">
-                <md-nav-list
-                    class="existing-map-list">
+                <md-nav-list>
                     <md-list-item
                         *ngFor="let map of maps"
                         (click)="selectMap(map)">

--- a/src/duckling/project/map-select.component.ts
+++ b/src/duckling/project/map-select.component.ts
@@ -11,14 +11,15 @@ import {openDialog} from '../util/md-dialog';
  */
 @Component({
     selector: "dk-map-select",
-    styleUrls: ["./duckling/layout.css"],
+    styleUrls: ["./duckling/layout.css", "./duckling/project/map-select.component.css"],
     template: `
         <div *ngIf="!listLoaded">
             <md-spinner></md-spinner>
         </div>
         <div *ngIf="listLoaded">
             <dk-section headerText="Select an Existing Map">
-                <md-nav-list>
+                <md-nav-list
+                    class="existing-map-list">
                     <md-list-item
                         *ngFor="let map of maps"
                         (click)="selectMap(map)">


### PR DESCRIPTION
* In map-select.component.ts, added a class to the md-nav-list of maps
* Created map-select.component.scss, which implements the css class (sets max-width and overflow-y)
* In map-select.component.ts, added a reference to the compiled css in styleUrls