### PR TITLE
Fix map-select dialog styling problems.

### DIFF
--- a/src/duckling/project/map-select.component.scss
+++ b/src/duckling/project/map-select.component.scss
@@ -1,4 +1,20 @@
+$listContainerWidth: 248px;
+
 md-nav-list {
-    max-height: 60%;
+    max-height: 60vh;
     overflow-y: auto;
+    overflow-x: hidden;
+    width: $listContainerWidth;
+}
+
+md-list-item {
+    width: $listContainerWidth - 16px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+.new-map-name-field {
+    margin-left: 20px;
+    margin-top: 12px;
 }

--- a/src/duckling/project/map-select.component.scss
+++ b/src/duckling/project/map-select.component.scss
@@ -9,9 +9,13 @@ md-nav-list {
 
 md-list-item {
     width: $listContainerWidth - 16px;
+}
+
+.map-name-container {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+    min-width: 0;
 }
 
 .new-map-name-field {

--- a/src/duckling/project/map-select.component.ts
+++ b/src/duckling/project/map-select.component.ts
@@ -25,7 +25,7 @@ import {openDialog} from '../util/md-dialog';
                         (click)="selectMap(map)">
                         <div 
                             class="map-name-container" 
-                            title="{{map}}">
+                            [title]="map">
                         {{map}}
                         </div>
                     </md-list-item>

--- a/src/duckling/project/map-select.component.ts
+++ b/src/duckling/project/map-select.component.ts
@@ -17,7 +17,8 @@ import {openDialog} from '../util/md-dialog';
             <md-spinner></md-spinner>
         </div>
         <div *ngIf="listLoaded">
-            <dk-section headerText="Select an Existing Map">
+            <dk-section 
+                headerText="Select an Existing Map">
                 <md-nav-list>
                     <md-list-item
                         *ngFor="let map of maps"
@@ -26,21 +27,20 @@ import {openDialog} from '../util/md-dialog';
                     </md-list-item>
                 </md-nav-list>
             </dk-section>
-            <dk-section headerText="Create a New Map">
-                <div>
-                    <dk-input class="dk-inline"
-                        label="New Map Name"
-                        [dividerColor]="newMapNameIsValid() ? 'primary' : 'warn'"
-                        (inputChanged)="newMapName = $event">
-                    </dk-input>
-                    <dk-icon-button
-                        icon="save"
-                        tooltip="Create the map"
-                        [disabled]="!newMapNameIsValid()"
-                        (click)="createMap()">
-                    </dk-icon-button>
-                </div>
-            </dk-section>
+            <div class="new-map-name-field">
+                <dk-input class="dk-inline"
+                    label="New Map Name"
+                    [dividerColor]="newMapNameIsValid() ? 'primary' : 'warn'"
+                    (inputChanged)="newMapName = $event">
+                </dk-input>
+                <dk-icon-button
+                    icon="plus"
+                    tooltip="Create the map"
+                    [disabled]="!newMapNameIsValid()"
+                    (click)="createMap()">
+                </dk-icon-button>
+            </div>
+
         </div>
     `
 })

--- a/src/duckling/project/map-select.component.ts
+++ b/src/duckling/project/map-select.component.ts
@@ -23,7 +23,11 @@ import {openDialog} from '../util/md-dialog';
                     <md-list-item
                         *ngFor="let map of maps"
                         (click)="selectMap(map)">
+                        <div 
+                            class="map-name-container" 
+                            title="{{map}}">
                         {{map}}
+                        </div>
                     </md-list-item>
                 </md-nav-list>
             </dk-section>


### PR DESCRIPTION
Resolves #280 

**Commit message:**
Change styles applied to and layout of map-select.component

`https://github.com/ild-games/duckling/issues/280`

Previously, a fix that limited the height of the map-selection dialog used % heights. Recent css changes invalidated this usage of percentage for the height, as there was no longer a set height for the element to roll up to ([commit #277](https://github.com/ild-games/duckling/commit/662db3aa39ed27e404029bbcc54cca452f6c186b)).

Now use vh instead of % for the height of the nav-list that contains the maps. 

Additionally, we removed some unnecessary card styling and switched the action icon for adding a new map