### PR TITLE
Allow path gizmos to be hidden

### DIFF
--- a/src/duckling/canvas/drawing/entity-drawer.service.ts
+++ b/src/duckling/canvas/drawing/entity-drawer.service.ts
@@ -78,10 +78,10 @@ export class EntityDrawerService extends BaseAttributeService<AttributeDrawer<At
      */
     drawEntity(entity : Entity) : DrawnConstruct[] {
         let drawnConstructs : DrawnConstruct[] = [];
-        if (!this._layers.isEntityVisible(entity)) {
-            return drawnConstructs;
-        }
         for (let key in entity) {
+            if (!this._layers.isEntityAttributeVisible(entity, key)) {
+                continue;
+            }
             let drawableConstruct = this.drawAttribute(key, entity);
             if (drawableConstruct) {
                 drawnConstructs.push(drawableConstruct);

--- a/src/duckling/entitysystem/services/entity-layer.service.ts
+++ b/src/duckling/entitysystem/services/entity-layer.service.ts
@@ -85,7 +85,6 @@ export class EntityLayerService extends BaseAttributeService<LayerGetter> {
     }
 
     isEntityVisible(entity : Entity) : boolean {
-        // an entity is visible if any of its attributes are on visible layers
         for (let attributeKey in entity) {
             if (this.isEntityAttributeVisible(entity, attributeKey)) {
                 return true;
@@ -94,7 +93,7 @@ export class EntityLayerService extends BaseAttributeService<LayerGetter> {
         return false;
     }
 
-    isEntityAttributeVisible(entity: Entity, attributeKey: string){
+    isEntityAttributeVisible(entity: Entity, attributeKey: string) {
         let getLayerImpl = this.getImplementation(attributeKey);
         if (!getLayerImpl) { 
             return false; 
@@ -123,8 +122,6 @@ export function layerReducer(state : LayerState = { hiddenLayers: {} }, action :
             hiddenLayers: action.hiddenLayers
         }
     } else if (action.type === ACTION_OPEN_MAP) {
-
-        // clear layers if the current map is changing
         return { hiddenLayers: {} };
     }
     return state;

--- a/src/duckling/game/drawable/drawable-get-layer.ts
+++ b/src/duckling/game/drawable/drawable-get-layer.ts
@@ -5,6 +5,6 @@ import {immutableAssign} from '../../util';
 /**
  * Will be registered with the EntityLayerService.
  */
-export function getLayer(attribute : DrawableAttribute) : string {
+export function getDrawableLayer(attribute : DrawableAttribute) : string {
     return "" + attribute.topDrawable.renderPriority;
 }

--- a/src/duckling/game/index.ts
+++ b/src/duckling/game/index.ts
@@ -48,7 +48,8 @@ import {DrawableAttributeComponent} from './drawable/drawable-attribute.componen
 import {drawDrawableAttribute} from './drawable/drawable-drawer';
 import {drawableBoundingBox} from './drawable/drawable-bounding-box';
 import {entityRequiredDrawableAssets} from './drawable/drawable-required-assets';
-import {getLayer} from './drawable/get-layer';
+import {getDrawableLayer} from './drawable/drawable-get-layer';
+import {getPathLayer} from './path/path-get-layer';
 
 type Services = {
     attributeDefaultService : AttributeDefaultService;
@@ -112,7 +113,7 @@ function _bootstrapDrawableAttribute(services : Services) {
     services.entityDrawerService.register(DRAWABLE_KEY, drawDrawableAttribute);
     services.requiredAssetService.register(DRAWABLE_KEY, entityRequiredDrawableAssets);
     services.requiredAssetService.register(DRAWABLE_KEY, entityRequiredDrawableAssets);
-    services.entityLayerService.register(DRAWABLE_KEY, getLayer);
+    services.entityLayerService.register(DRAWABLE_KEY, getDrawableLayer);
 }
 
 function _bootstrapActionAttribute(services : Services) {
@@ -135,6 +136,7 @@ function _bootstrapPathAttribute(services : Services) {
     services.attributeDefaultService.register(PATH_KEY, {createByDefault: false, default: defaultPath});
     services.entityDrawerService.register(PATH_KEY, drawPathAttribute);
     services.entityBoxService.register(PATH_KEY, pathBox);
+    services.entityLayerService.register(PATH_KEY, getPathLayer); 
 }
 
 function _bootstrapPathFollowerAttribute(services : Services) {

--- a/src/duckling/game/path/path-get-layer.ts
+++ b/src/duckling/game/path/path-get-layer.ts
@@ -1,0 +1,10 @@
+import {PathAttribute} from './path-attribute';
+import {Vector} from '../../math';
+import {immutableAssign} from '../../util';
+
+/**
+ * Will be registered with the EntityLayerService.
+ */
+export function getPathLayer(attribute : PathAttribute) : string {
+    return "path-gizmos";
+}


### PR DESCRIPTION
Resolves #291 
Added an implementation for the layer service to path attributes.

`https://github.com/ild-games/duckling/issues/291`

Paths did not implement a function for the layer service. We now return a string "path-gizmos" for any entity that has a path attribute from a "getPathLayer" function which is bootstrapped into the entity-layer service