### PR TITLE
Load initial-map from metadata file

### DIFF
--- a/src/duckling-tests/game/collision/collision-types.service.spec.ts
+++ b/src/duckling-tests/game/collision/collision-types.service.spec.ts
@@ -13,7 +13,7 @@ import {mainReducer} from '../../../duckling/main.reducer';
 import {mergeEntityAction} from '../../../duckling/entitysystem';
 
 class MockProjectService {
-    getMetaDataPath(metaData : string) : string{
+    getProjectMetaDataPath(metaData : string) : string{
         return `META_DATA_${metaData}`;
     }
 }

--- a/src/duckling/game/collision/collision-types.service.ts
+++ b/src/duckling/game/collision/collision-types.service.ts
@@ -38,7 +38,7 @@ export class CollisionTypesService {
     }
 
     async postLoadMapHook(map : RawMapFile)  : Promise<RawMapFile> {
-        let json = await this._jsonLoader.getJsonFromPath(this._project.getMetaDataPath("collision-types"));
+        let json = await this._jsonLoader.getJsonFromPath(this._project.getProjectMetaDataPath("collision-types"));
         if (this._tryParseJsonFile(json)) {
             this._registerAnconaCollisionTypes(JSON.parse(json));
         } else {
@@ -123,7 +123,7 @@ export class CollisionTypesService {
 
     private _saveCollisionTypesMetaData() {
         let json = JSON.stringify({collisionTypes: Array.from(this.collisionTypes.getValue().values())}, null, 4);
-        this._jsonLoader.saveJsonToPath(this._project.getMetaDataPath("collision-types"), json);
+        this._jsonLoader.saveJsonToPath(this._project.getProjectMetaDataPath("collision-types"), json);
     }
 
     private _tryParseJsonFile(jsonStream : string) : boolean {

--- a/src/duckling/project/project.service.ts
+++ b/src/duckling/project/project.service.ts
@@ -33,7 +33,7 @@ const DEFAULT_INITIAL_MAP = "map1";
 const USER_META_DATA_FILE = "user-preferences";
 
 export type UserMetaData = {
-    initialMap: string
+    initialMap?: string
 }
 
 /**
@@ -150,26 +150,18 @@ export class ProjectService {
 
     private async _loadUserMetaData() : Promise<UserMetaData> {
         let fileExists = await this._pathService.pathExists(this.getUserMetaDataPath(USER_META_DATA_FILE));
+        let userPreferences : UserMetaData = {};
         if (fileExists) {
             let json = await this._jsonLoader.getJsonFromPath(this.getUserMetaDataPath(USER_META_DATA_FILE));
-            let userPreferences = JSON.parse(json);
-            await this._fillMissingUserPreferences(userPreferences);
-            return userPreferences;
+            userPreferences = JSON.parse(json);
         }
 
-        return this._newUserPreferences();
+        return this._fillMissingUserPreferences(userPreferences);
     }
 
     private async _fillMissingUserPreferences(metaData : UserMetaData) : Promise<UserMetaData> {
         metaData["initialMap"] = metaData["initialMap"] || await this._initialUserPreferenceMap();
         return metaData;
-    }
-
-    private async _newUserPreferences() : Promise<UserMetaData> {
-        let initialMap = await this._initialUserPreferenceMap();
-        return {
-            initialMap
-        };
     }
 
     private async _initialUserPreferenceMap() : Promise<string> {

--- a/src/duckling/project/project.service.ts
+++ b/src/duckling/project/project.service.ts
@@ -30,7 +30,11 @@ import {CustomAttribute} from './custom-attribute';
 
 const MAP_DIR = "maps";
 const DEFAULT_INITIAL_MAP = "map1";
-const INITIAL_MAP_FILE = "initial-map";
+const USER_META_DATA_FILE = "user-preferences";
+
+export type UserMetaData = {
+    initialMap: string
+}
 
 /**
  * The project service provides access to project level state and operations.
@@ -63,8 +67,11 @@ export class ProjectService {
             let versionInfo = await this._migrationService.openProject(projectPath);
             this._storeService.dispatch(setVersionInfo(versionInfo));
             await this._loadProjectMetaData();
-            let mapName = await this._loadInitialMap();
-            await this.openMap(mapName);
+
+            // if, in the future, user meta data needs to be accessed after the initial project
+            // open, it should be a member on the project and put in the rxjs store.
+            let userMetaData = await this._loadUserMetaData();
+            await this.openMap(userMetaData.initialMap);
         } catch (error) {
             this._dialog.showErrorDialog("Unable to Open the Project", error.message);
         }
@@ -112,7 +119,7 @@ export class ProjectService {
             }, this._project.versionInfo);
         let json = JSON.stringify(map, null, 4);
         await this._saveProjectMetaData();
-        await this._saveInitialMap(this._project.currentMap.key);
+        await this._saveUserMetaData(this._buildUserMetaData());
         await this._jsonLoader.saveJsonToPath(this.getMapPath(this._project.currentMap.key), json);
         this._snackbar.invokeSnacks();
     }
@@ -133,30 +140,45 @@ export class ProjectService {
         }
     }
 
-    private async _loadInitialMap() : Promise<string> {
-        let initialMapFileExists = await this._pathService.pathExists(this.getMetaDataPath(INITIAL_MAP_FILE));
-        if (initialMapFileExists) {
-            let json = await this._jsonLoader.getJsonFromPath(this.getMetaDataPath(INITIAL_MAP_FILE));
-            let initialMapData = JSON.parse(json);
-            if (initialMapData["initialMap"]) {
-                return initialMapData["initialMap"];
-            }
-        }
-
-        let mapNames = await this.getMaps();
-        if (mapNames.length > 0) {
-            return mapNames[0];
-        }
-
-        return DEFAULT_INITIAL_MAP;
-    }
-
-    private async _saveInitialMap(mapName : string) : Promise<void> {
-        let json = JSON.stringify({initialMap: mapName}, null, 4);
-        let saveResult = await this._jsonLoader.saveJsonToPath(this.getMetaDataPath(INITIAL_MAP_FILE), json);
+    private async _saveUserMetaData(userMetaData : UserMetaData) : Promise<void> {
+        let json = JSON.stringify(userMetaData, null, 4);
+        let saveResult = await this._jsonLoader.saveJsonToPath(this.getUserMetaDataPath(USER_META_DATA_FILE), json);
         if (!saveResult.isSuccess) {
             this._snackbar.addSnack("Error: There was a problem saving last opened map!");
         }
+    }
+
+    private async _loadUserMetaData() : Promise<UserMetaData> {
+        let fileExists = await this._pathService.pathExists(this.getUserMetaDataPath(USER_META_DATA_FILE));
+        if (fileExists) {
+            let json = await this._jsonLoader.getJsonFromPath(this.getUserMetaDataPath(USER_META_DATA_FILE));
+            let userPreferences = JSON.parse(json);
+            await this._fillMissingUserPreferences(userPreferences);
+            return userPreferences;
+        }
+
+        return this._newUserPreferences();
+    }
+
+    private async _fillMissingUserPreferences(metaData : UserMetaData) : Promise<UserMetaData> {
+        metaData["initialMap"] = metaData["initialMap"] || await this._initialUserPreferenceMap();
+        return metaData;
+    }
+
+    private async _newUserPreferences() : Promise<UserMetaData> {
+        let initialMap = await this._initialUserPreferenceMap();
+        return {
+            initialMap
+        };
+    }
+
+    private async _initialUserPreferenceMap() : Promise<string> {
+        let initialMap = DEFAULT_INITIAL_MAP;
+        let mapNames = await this.getMaps();
+        if (mapNames.length > 0) {
+            initialMap = mapNames[0];
+        }
+        return initialMap;
     }
 
     /**
@@ -229,27 +251,22 @@ export class ProjectService {
      * @param metaDataFile The name of the meta data file stored in the project/ folder (excluding file type)
      * @return the path that can be used to load the meta data file
      */
-    getMetaDataPath(metaDataFile : string) : string {
-        return this._pathService.join(this.metaDataDir, metaDataFile + ".json");
+    getProjectMetaDataPath(metaDataFile : string) : string {
+        return this._pathService.join(this.projectMetaDataDir, metaDataFile + ".json");
     }
 
     /**
-     * The project's root directory.
+     * Get the path to a specific meta data file for the user.
+     * @param metaDataFile The name of the meta data file stored in the .duckling/ folder (excluding file type)
+     * @return the path that can be used to load the meta data file
      */
-    get home() {
-        return this._project.home;
-    }
-
-    /**
-     * The directory project metadata is stored in.
-     */
-    get metaDataDir() : string {
-        return this._pathService.join(this.home, "project");
+    getUserMetaDataPath(metaDataFile : string) : string {
+        return this._pathService.join(this.userMetaDataDir, metaDataFile + ".json");
     }
 
     private async _parseMapJson(json : any, key : string) {
         let rawMap = json ? JSON.parse(json) : createRawMap(this._project.versionInfo.mapVersion);
-        rawMap = await this._migrationService.migrateMap(rawMap, this._project.versionInfo, this.metaDataDir);
+        rawMap = await this._migrationService.migrateMap(rawMap, this._project.versionInfo, this.projectMetaDataDir);
 
         let parsedMap = await this._mapParser.rawMapToParsedMap(rawMap);
 
@@ -271,6 +288,12 @@ export class ProjectService {
         this._storeService.dispatch(clearUndoHistoryAction());
     }
 
+    private _buildUserMetaData() : UserMetaData {
+        return {
+            initialMap: this._project.currentMap.key
+        };
+    }
+
     private _mapPathToRoot(root : string, path : string) {
         return path.slice(root.length+1, -(".map".length));
     }
@@ -289,5 +312,23 @@ export class ProjectService {
 
     private get _project() : Project {
         return this._storeService.getState().project;
+    }
+
+    get home() {
+        return this._project.home;
+    }
+
+    /**
+     * the directory project metadata is stored in.
+     */
+    get projectMetaDataDir() : string {
+        return this._pathService.join(this.home, "project");
+    }
+
+    /**
+     * the directory user metadata is stored in.
+     */
+    get userMetaDataDir() : string {
+        return this._pathService.join(this.home, ".duckling");
     }
 }


### PR DESCRIPTION
Resolves #301 
**Commit message:**
Determine which map to load in at first from a metadata file "initial-map.json". If this file isn't present load in the first map found in the maps/ folder alphabetically. If there are no maps found, load "map1.map" as we had done before. When saving a map, write that map to "initial-map.json" so it will be loaded upon restarting duckling.

`https://github.com/ild-games/duckling/issues/301`

When loading a project in duckling the first map to be loaded upon starting was always "map1.map". This usually was unwanted because usually it wasn't a saved map on the project and there are other saved maps. This will open the last saved map.