### PR TITLE
improve accordion performance

### DIFF
--- a/src/duckling/controls/accordian.component.ts
+++ b/src/duckling/controls/accordian.component.ts
@@ -28,6 +28,7 @@ import {TemplateWrapperDirective} from './template-wrapper.directive';
             (cloned)="onElementCloned(index)"
             (moved)="onElementMoved(index, $event)">
             <ng-template
+                *ngIf="openedElements[keyForIndex(index)]"
                 [templateWrapper]="elementTemplate"
                 [context]="elementContext(index)">
             </ng-template>


### PR DESCRIPTION
Resolves #309 
**Commit message:**
Greatly improve accordion performance when first opened

`https://github.com/ild-games/duckling/issues/309`

The accordion performance was incredibly bad (~5 seconds on large instances) when the component is first created. This is because change detection is happening for all child components at first. This fixes it by hiding the children under an ngIf