### PR TITLE
Don't recreate display objects when the entity system is modified

### DIFF
--- a/src/duckling/canvas/drawing/entity-drawer.service.ts
+++ b/src/duckling/canvas/drawing/entity-drawer.service.ts
@@ -132,12 +132,6 @@ export class EntityDrawerService extends BaseAttributeService<AttributeDrawer<At
         return attributeLayers;
     }
 
-    toggleAttributeVisibility(attributeKey : string, mergeKey? : any) {
-        let patchAttributes : HiddenAttributes = {};
-        patchAttributes[attributeKey] = !this._layers.layers.value.hiddenAttributes[attributeKey];
-        this._store.dispatch(layerAttributeAction(immutableAssign(this._layers.layers.value.hiddenAttributes, patchAttributes)), mergeKey);
-    }
-
     isEntityVisible(entity : Entity) : boolean {
         for (let attributeKey in entity) {
             if (!this.isAttributeVisible(attributeKey, entity)) {

--- a/src/duckling/canvas/drawing/entity-drawer.service.ts
+++ b/src/duckling/canvas/drawing/entity-drawer.service.ts
@@ -19,7 +19,11 @@ import {DrawnConstruct} from './drawn-construct';
 
 export type AttributeDrawer<T> = (attribute : T, assetService? : AssetService, position? : Vector) => DrawnConstruct;
 
-type EntityCache = {[key:string]:EntityCacheEntry};
+export interface EntityCache {
+    cache? : EntityCacheInternal;
+}
+
+type EntityCacheInternal = {[key:string]:EntityCacheEntry};
 
 interface EntityCacheEntry {
     entity : Entity,
@@ -28,8 +32,10 @@ interface EntityCacheEntry {
 
 @Injectable()
 export class EntityDrawerService extends BaseAttributeService<AttributeDrawer<Attribute>> {
-    hiddenAttributes : BehaviorSubject<HiddenAttributes>;
-    invalidateDrawableCache : BehaviorSubject<boolean>;
+    /**
+     * Publish true if the cache is still valid.
+     */
+    redraw : BehaviorSubject<boolean>;
 
     constructor(private _assets : AssetService,
                 private _renderPriority : RenderPriorityService,
@@ -39,30 +45,38 @@ export class EntityDrawerService extends BaseAttributeService<AttributeDrawer<At
                 private _availabeAttributes : AvailableAttributeService,
                 private _store : StoreService) {
         super();
-        this.invalidateDrawableCache = new BehaviorSubject(false);
+        this.redraw = new BehaviorSubject(false);
 
-        _assets.assetLoaded.subscribe(() => this._clearCache());
-        _assets.preloadImagesLoaded.subscribe(() => this._clearCache());
-        _layers.hiddenLayers.subscribe(() => this._clearCache());
-        _entitySystem.entitySystem.subscribe(() => this._clearCache());
-        
-        this.hiddenAttributes = new BehaviorSubject({});
-        this.hiddenAttributes.subscribe(() => this._clearCache());
-        this._store.state.subscribe(state => {
-            if (state.layers.hiddenAttributes !== this.hiddenAttributes.value) {
-                this.hiddenAttributes.next(state.layers.hiddenAttributes ? state.layers.hiddenAttributes : {});
-            }
-        });
+        _assets.assetLoaded.subscribe(() => this._redraw());
+        _assets.preloadImagesLoaded.subscribe(() => this._redraw());
+        _layers.layers.subscribe(() => this._redraw());
+        _entitySystem.entitySystem.subscribe(() => this._redraw(true));
     }
 
-    drawEntitySystem(entitySystem : EntitySystem) : DrawnConstruct[] {
+    drawEntitySystem(entitySystem : EntitySystem, cache? : EntityCache) : DrawnConstruct[] {
         let drawnConstructs : DrawnConstruct[] = [];
-        let newCache : EntityCache = {};
+        let newCache : EntityCacheInternal = {}
+        let oldCache : EntityCacheInternal = (cache && cache.cache) ? cache.cache : {};
+
         entitySystem.forEach((entity, entityKey) => {
-            for (let construct of this.getEntityDrawable(entity)) {
-                drawnConstructs.push(construct);
+            if (oldCache[entityKey] && oldCache[entityKey].entity === entity) {
+                for (let construct of oldCache[entityKey].renderedEntity) {
+                    drawnConstructs.push(construct);
+                }
+                newCache[entityKey] = oldCache[entityKey];
+            } else {
+                let renderedEntity = this.getEntityDrawable(entity);
+                for (let construct of renderedEntity) {
+                    drawnConstructs.push(construct);
+                }
+                newCache[entityKey] = {entity, renderedEntity};
             }
         });
+
+        if (cache) {
+            cache.cache = newCache;
+        }
+
         return drawnConstructs;
     }
 
@@ -120,10 +134,10 @@ export class EntityDrawerService extends BaseAttributeService<AttributeDrawer<At
 
     toggleAttributeVisibility(attributeKey : string, mergeKey? : any) {
         let patchAttributes : HiddenAttributes = {};
-        patchAttributes[attributeKey] = !this.hiddenAttributes.value[attributeKey];
-        this._store.dispatch(layerAttributeAction(immutableAssign(this.hiddenAttributes.value, patchAttributes)), mergeKey);
+        patchAttributes[attributeKey] = !this._layers.layers.value.hiddenAttributes[attributeKey];
+        this._store.dispatch(layerAttributeAction(immutableAssign(this._layers.layers.value.hiddenAttributes, patchAttributes)), mergeKey);
     }
-    
+
     isEntityVisible(entity : Entity) : boolean {
         for (let attributeKey in entity) {
             if (!this.isAttributeVisible(attributeKey, entity)) {
@@ -148,9 +162,9 @@ export class EntityDrawerService extends BaseAttributeService<AttributeDrawer<At
         }
 
 
-        return (!this.hiddenAttributes.value[attributeKey]);
+        return (!this._layers.layers.value.hiddenAttributes[attributeKey]);
     }
-    
+
     private _getImplementedAttributes() : AttributeKey[] {
         let implementedAttributes : AttributeKey[] = [];
         for (let attributeKey of this._availabeAttributes.availableAttributes()) {
@@ -161,8 +175,7 @@ export class EntityDrawerService extends BaseAttributeService<AttributeDrawer<At
         return implementedAttributes;
     }
 
-
-    private _clearCache() {
-        this.invalidateDrawableCache.next(true);
+    private _redraw(entityCacheValid : boolean = false) {
+        this.redraw.next(entityCacheValid);
     }
 }

--- a/src/duckling/entitysystem/services/entity-layer.service.ts
+++ b/src/duckling/entitysystem/services/entity-layer.service.ts
@@ -85,6 +85,13 @@ export class EntityLayerService extends BaseAttributeService<LayerGetter> {
         this._store.dispatch(_layerAction(immutableAssign(this.layers.value.hiddenLayers, patchLayers)), mergeKey);
     }
 
+    toggleAttributeVisibility(attributeKey : string, mergeKey? : any) {
+        let patchAttributes : HiddenAttributes = {};
+        patchAttributes[attributeKey] = !this.layers.value.hiddenAttributes[attributeKey];
+        this._store.dispatch(layerAttributeAction(immutableAssign(this.layers.value.hiddenAttributes, patchAttributes)), mergeKey);
+    }
+
+
     isEntityOnAnActiveLayer(entity : Entity) : boolean {
         for (let attributeKey in entity) {
             if (this.isAttributeOnAnActiveLayer(entity, attributeKey)) {

--- a/src/duckling/entitysystem/services/entity-layer.service.ts
+++ b/src/duckling/entitysystem/services/entity-layer.service.ts
@@ -32,16 +32,16 @@ export type AttributeLayer = {
 @Injectable()
 export class EntityLayerService extends BaseAttributeService<LayerGetter> {
 
-    hiddenLayers : BehaviorSubject<HiddenLayers>;
+    layers : BehaviorSubject<LayerState>;
 
     constructor(private _entitySystemService : EntitySystemService,
                 private _store : StoreService) {
         super();
 
-        this.hiddenLayers = new BehaviorSubject({});
+        this.layers = new BehaviorSubject({hiddenLayers : {}, hiddenAttributes : {}});
         this._store.state.subscribe(state => {
-            if (state.layers.hiddenLayers !== this.hiddenLayers.value) {
-                this.hiddenLayers.next(state.layers.hiddenLayers ? state.layers.hiddenLayers : {});
+            if (state.layers !== this.layers.value) {
+                this.layers.next(state.layers);
             }
         });
     }
@@ -56,11 +56,11 @@ export class EntityLayerService extends BaseAttributeService<LayerGetter> {
                 let getLayerImpl = this.getImplementation(attributeKey);
                 if (!getLayerImpl) { continue; }
                 let layerKey = getLayerImpl(entity[attributeKey]);
-                
+
                 if (!layersAccountedFor.has(layerKey) && layerKey !== undefined && layerKey !== null) {
                     layers.push({
                         layerName: layerKey,
-                        isVisible: !this.hiddenLayers.value[layerKey]
+                        isVisible: !this.layers.value.hiddenLayers[layerKey]
                     });
                     layersAccountedFor.add(layerKey);
                 }
@@ -81,8 +81,8 @@ export class EntityLayerService extends BaseAttributeService<LayerGetter> {
 
     toggleLayerVisibility(layerKey : string, mergeKey? : any) {
         let patchLayers : HiddenLayers = {};
-        patchLayers[layerKey] = !this.hiddenLayers.value[layerKey];
-        this._store.dispatch(_layerAction(immutableAssign(this.hiddenLayers.value, patchLayers)), mergeKey);
+        patchLayers[layerKey] = !this.layers.value.hiddenLayers[layerKey];
+        this._store.dispatch(_layerAction(immutableAssign(this.layers.value.hiddenLayers, patchLayers)), mergeKey);
     }
 
     isEntityOnAnActiveLayer(entity : Entity) : boolean {
@@ -101,7 +101,7 @@ export class EntityLayerService extends BaseAttributeService<LayerGetter> {
         }
 
         let layerKey : string  = getLayerImpl(entity[attributeKey]);
-        return (!this.hiddenLayers.value[layerKey]);
+        return (!this.layers.value.hiddenLayers[layerKey]);
     }
 
     isAttributeImplemented(attributeKey : string) {
@@ -113,12 +113,12 @@ export class EntityLayerService extends BaseAttributeService<LayerGetter> {
 /**
  * State for the current layers
  */
-interface LayerState {
-    hiddenLayers?: HiddenLayers;
-    hiddenAttributes?: HiddenAttributes;
+export interface LayerState {
+    hiddenLayers: HiddenLayers;
+    hiddenAttributes: HiddenAttributes;
 }
 
-export function layerReducer(state : LayerState = { hiddenLayers: {}, hiddenAttributes: {} }, action : LayerAction) {
+export function layerReducer(state : LayerState = { hiddenLayers: {}, hiddenAttributes: {} }, action : LayerAction) : LayerState {
     if (action.type === ACTION_TOGGLE_LAYER_VISIBILITY) {
         return {
             ...state,
@@ -130,7 +130,7 @@ export function layerReducer(state : LayerState = { hiddenLayers: {}, hiddenAttr
             hiddenAttributes: action.hiddenAttributes,
         }
     } else if (action.type === ACTION_OPEN_MAP) {
-        return { hiddenLayers: {} };
+        return { hiddenLayers: {}, hiddenAttributes : {}};
     }
     return state;
 }

--- a/src/duckling/entitysystem/services/layer-dialog.component.ts
+++ b/src/duckling/entitysystem/services/layer-dialog.component.ts
@@ -84,11 +84,8 @@ export class LayerDialogComponent implements AfterViewInit, OnDestroy{
     }
 
     ngAfterViewInit() {
-        this._layerSubscription = this._entityLayerService.hiddenLayers.subscribe(() => {
+        this._layerSubscription = this._entityLayerService.layers.subscribe(() => {
             this._refreshLayers();
-        }) as Subscriber<any>;
-
-        this._attributeLayerSubscription = this._entityDrawerService.hiddenAttributes.subscribe(() => {
             this._refreshAttributes();
         }) as Subscriber<any>;
     }

--- a/src/duckling/entitysystem/services/layer-dialog.component.ts
+++ b/src/duckling/entitysystem/services/layer-dialog.component.ts
@@ -100,7 +100,7 @@ export class LayerDialogComponent implements AfterViewInit, OnDestroy{
     }
 
     toggleAttributeVisibility(attributeLayer : AttributeLayer) {
-        this._entityDrawerService.toggleAttributeVisibility(attributeLayer.attributeName);
+        this._entityLayerService.toggleAttributeVisibility(attributeLayer.attributeName);
     }
 
     private _refreshLayers() {


### PR DESCRIPTION
Resolves #312 
**Commit message:**
Reintroduce the entity-specific drawing cache

`https://github.com/ild-games/duckling/issues/312`

Drawing PIXI objects is cheap. Allocating PIXI objects is expensive. Previously, when the entity system is modified, we would recreate all PIXI objects representing entities. Now, we only create PIXI objects for the entities that have changed.