### PR TITLE
Editor built in migrations

### DIFF
--- a/src/duckling-tests/migration/existing-migration.spec.ts
+++ b/src/duckling-tests/migration/existing-migration.spec.ts
@@ -9,7 +9,6 @@ import { MigrationTools } from '../../duckling/migration/migration-tools';
 import { ParsedMap } from '../../duckling/project/map-parser.service';
 import { EntitySystem, Entity, EntityKey } from '../../duckling/entitysystem/entity';
 
-
 const MIGRATION_FILE: ProjectVersionInfo = {
     mapVersion: "1.0",
     mapMigrations: [
@@ -69,7 +68,6 @@ describe("MigrationService", function () {
         migrationService.registerExistingCodeMigration(fakeCollisionMigration);
     });
 
-
     describe("migrateMap", () => {
         it("Runs existing code on a raw map", async function () {
             let map = await migrationService.migrateMap(RAW_MAP, MIGRATION_FILE, "THE_ROOT");
@@ -77,11 +75,10 @@ describe("MigrationService", function () {
         });
     });
 
-    describe("updateVersionFileWithExistingCodeMigration", () => {
+    describe("updateVersionInfoWithExistingCodeMigration", () => {
 
-        const PRE_MIGRATION_VERSION_FILE = {
-            projectVersion: "1.0",
-            editorVersion: "0.1",
+        const PRE_MIGRATION_VERSION_INFO : ProjectVersionInfo = {
+            mapVersion: "1.0",
             mapMigrations: [
                 {
                     type: "code",
@@ -91,9 +88,8 @@ describe("MigrationService", function () {
             ]
         };
 
-        const EXPECTED_VERSION_FILE = {
-            projectVersion: "2.0",
-            editorVersion: "0.1",
+        const EXPECTED_VERSION_INFO = {
+            mapVersion: "2.0",
             mapMigrations: [
                 {
                     type: "code",
@@ -112,36 +108,34 @@ describe("MigrationService", function () {
             ]
         };
 
-        let versionFileJson: any;
+        let versionInfo: any;
 
         beforeEach(() => {
-            versionFileJson = Object.assign({}, PRE_MIGRATION_VERSION_FILE);
-            versionFileJson = migrationService.updateVersionFileWithExistingCodeMigration(
-                versionFileJson,
+            versionInfo = Object.assign({}, PRE_MIGRATION_VERSION_INFO);
+            versionInfo = migrationService.updateVersionInfoWithExistingCodeMigration(
+                versionInfo,
                 "collision",
                 { oldType: "oldType", newType: "newType" });
         });
 
         describe("the existing-code migration that it adds", () => {
-
             it("has an 'updateTo' equal to the new project version in the file", () => {
-                expect(versionFileJson.mapMigrations[1].updateTo).to.eql(EXPECTED_VERSION_FILE.projectVersion);
+                expect(versionInfo.mapMigrations[1].updateTo).to.eql(EXPECTED_VERSION_INFO.mapVersion);
             });
 
             it("has the options that were provided", () => {
-                expect(versionFileJson.mapMigrations[1].options).to.eql((EXPECTED_VERSION_FILE.mapMigrations[1] as any).options);
+                expect(versionInfo.mapMigrations[1].options).to.eql((EXPECTED_VERSION_INFO.mapMigrations[1] as any).options);
             });
         });
 
         it("increments the project version", () => {
-            expect(versionFileJson.projectVersion).to.eql(EXPECTED_VERSION_FILE.projectVersion);
+            expect(versionInfo.mapVersion).to.eql(EXPECTED_VERSION_INFO.mapVersion);
         });
     });
 
     describe("migrateEntitySystem", () => {
 
         let entitySystem: EntitySystem;
-
 
         const ENTITY_SYSTEM: EntitySystem = Map<EntityKey, Entity>({
             entity1: {
@@ -169,7 +163,6 @@ describe("MigrationService", function () {
             }
         });
 
-
         beforeEach(() => {
             entitySystem = Map(ENTITY_SYSTEM); 
         });
@@ -184,6 +177,5 @@ describe("MigrationService", function () {
                 "fake-collision-migration", 
                 { oldType: "oldType", newType: "newType"})).to.eql(MIGRATED_ENTITY_SYSTEM);
         });
-
     });
 });

--- a/src/duckling-tests/migration/existing-migration.spec.ts
+++ b/src/duckling-tests/migration/existing-migration.spec.ts
@@ -38,14 +38,6 @@ const RAW_MAP: any = {
     }
 }
 
-const ENTITY_SYSTEM: EntitySystem = Map<EntityKey, Entity>({
-    entity1: {
-        collision: {
-            collisionType: "oldType"
-        }
-    }
-});
-
 let fakeCollisionMigration: ExistingCodeMigration = {
     rawMapFunction: (tools: MigrationTools) => {
         return tools.attributeMigration("collision", (attribute: any, options: any) => {
@@ -55,24 +47,143 @@ let fakeCollisionMigration: ExistingCodeMigration = {
             return attribute;
         });
     },
-    entitySystemFunction: () => { },
+    entitySystemFunction: (entitySystem: EntitySystem, options?: any) => { 
+        return entitySystem.map((entity: Entity) => {
+            for (let attributeKey in entity) {
+                if (attributeKey === "collision") {
+                    if ((entity.collision as any).collisionType === options.oldType) {
+                        (entity[attributeKey] as any).collisionType = options.newType;
+                    }
+                }
+            }
+            return entity;
+        }) as Map<EntityKey, Entity>;
+    },
     name: "fake-collision-migration"
 }
-
 
 describe("MigrationService", function () {
     let migrationService: MigrationService;
     beforeEach(function () {
         migrationService = new MigrationService(new PathService(), null);
-        migrationService.addExistingCodeMigration(fakeCollisionMigration);
+        migrationService.registerExistingCodeMigration(fakeCollisionMigration);
     });
 
-    it("Runs existing code on a raw map", async function () {
-        let map = await migrationService.migrateMap(RAW_MAP, MIGRATION_FILE, "THE_ROOT");
-        expect(map.systems.collision.components.entity1.collisionType).to.eql("newType");
+
+    describe("migrateMap", () => {
+        it("Runs existing code on a raw map", async function () {
+            let map = await migrationService.migrateMap(RAW_MAP, MIGRATION_FILE, "THE_ROOT");
+            expect(map.systems.collision.components.entity1.collisionType).to.eql("newType");
+        });
     });
 
-    it("Runs existing code on an open map", async function () {
-        let map = await migrationService.migrateMap()
+    describe("updateVersionFileWithExistingCodeMigration", () => {
+
+        const PRE_MIGRATION_VERSION_FILE = {
+            projectVersion: "1.0",
+            editorVersion: "0.1",
+            mapMigrations: [
+                {
+                    type: "code",
+                    updateTo: "1.0",
+                    name: "migrations/coin-migration"
+                }
+            ]
+        };
+
+        const EXPECTED_VERSION_FILE = {
+            projectVersion: "2.0",
+            editorVersion: "0.1",
+            mapMigrations: [
+                {
+                    type: "code",
+                    updateTo: "1.0",
+                    name: "migrations/coin-migration"
+                },
+                {
+                    type: "existing-code",
+                    updateTo: "2.0",
+                    name: "collision",
+                    options: {
+                        oldType: "oldType",
+                        newType: "newType"
+                    }
+                }
+            ]
+        };
+
+        let versionFileJson: any;
+
+        beforeEach(() => {
+            versionFileJson = Object.assign({}, PRE_MIGRATION_VERSION_FILE);
+            versionFileJson = migrationService.updateVersionFileWithExistingCodeMigration(
+                versionFileJson,
+                "collision",
+                { oldType: "oldType", newType: "newType" });
+        });
+
+        describe("the existing-code migration that it adds", () => {
+
+            it("has an 'updateTo' equal to the new project version in the file", () => {
+                expect(versionFileJson.mapMigrations[1].updateTo).to.eql(EXPECTED_VERSION_FILE.projectVersion);
+            });
+
+            it("has the options that were provided", () => {
+                expect(versionFileJson.mapMigrations[1].options).to.eql((EXPECTED_VERSION_FILE.mapMigrations[1] as any).options);
+            });
+        });
+
+        it("increments the project version", () => {
+            expect(versionFileJson.projectVersion).to.eql(EXPECTED_VERSION_FILE.projectVersion);
+        });
+    });
+
+    describe("migrateEntitySystem", () => {
+
+        let entitySystem: EntitySystem;
+
+
+        const ENTITY_SYSTEM: EntitySystem = Map<EntityKey, Entity>({
+            entity1: {
+                collision: {
+                    collisionType: "oldType"
+                }
+            },
+            entity2: {
+                drawable: {
+                    drawableData: "drawableData"
+                }
+            }
+        });
+
+        const MIGRATED_ENTITY_SYSTEM: EntitySystem = Map<EntityKey, Entity>({
+            entity1: {
+                collision: {
+                    collisionType: "newType"
+                }
+            },
+            entity2: {
+                drawable: {
+                    drawableData: "drawableData"
+                }
+            }
+        });
+
+
+        beforeEach(() => {
+            entitySystem = Map(ENTITY_SYSTEM); 
+        });
+
+        it("throws an error when an unregistered existing-code migration is provided", () => {
+            expect(() => migrationService.migrateEntitySystem(entitySystem, "invalid-migration", {})).to.throw(Error);
+        });
+
+        it ("runs a registered existing code migration", () => {
+            expect(migrationService.migrateEntitySystem(
+                entitySystem, 
+                "fake-collision-migration", 
+                { oldType: "oldType", newType: "newType"})).to.eql(MIGRATED_ENTITY_SYSTEM);
+        });
+
     });
 });

--- a/src/duckling-tests/migration/existing-migration.spec.ts
+++ b/src/duckling-tests/migration/existing-migration.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+
+import { MigrationService, ProjectVersionInfo } from '../../duckling/migration/migration.service';
+import { PathService } from '../../duckling/util/path.service';
+import { ChangeType, changeType } from '../../duckling/state/object-diff';
+import { ExistingCodeMigration } from '../../duckling/migration/existing-code-migration';
+import { MigrationTools } from '../../duckling/migration/migration-tools';
+
+
+const MIGRATION_FILE: ProjectVersionInfo = {
+    mapVersion: "1.0",
+    mapMigrations: [
+        {
+            type: "existing-code",
+            updateTo: "1.0",
+            name: "fake-collision-migration",
+            options: {
+                oldType: "oldType",
+                newType: "newType"
+            }
+        },
+    ]
+}
+
+const RAW_MAP: any = {
+    version: "0.0",
+    systems: {
+        collision: {
+            components: {
+                entity1: {
+                    collisionType: "oldType"
+                }
+            }
+        }
+    }
+}
+
+let fakeCollisionMigration: ExistingCodeMigration = {
+    function: (tools: MigrationTools) => {
+        return tools.attributeMigration("collision", (attribute: any, options: any) => {
+            if (attribute.collisionType === options.oldType) {
+                attribute.collisionType = options.newType;
+            }
+            return attribute;
+        });
+    },
+    name: "fake-collision-migration"
+}
+
+
+describe("MigrationService", function () {
+    let migrationService: MigrationService;
+    beforeEach(function () {
+        migrationService = new MigrationService(new PathService(), null);
+        migrationService.addExistingCodeMigration(fakeCollisionMigration);
+    });
+
+    it("Runs existing code on a raw map", async function () {
+        let map = await migrationService.migrateMap(RAW_MAP, MIGRATION_FILE, "THE_ROOT");
+        expect(map.systems.collision.components.entity1.collisionType).to.eql("newType");
+    });
+});

--- a/src/duckling-tests/migration/existing-migration.spec.ts
+++ b/src/duckling-tests/migration/existing-migration.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { Map } from 'immutable';
 
-import { MigrationService, ProjectVersionInfo } from '../../duckling/migration/migration.service';
+import { MigrationService, VersionFile } from '../../duckling/migration/migration.service';
 import { PathService } from '../../duckling/util/path.service';
 import { ChangeType, changeType } from '../../duckling/state/object-diff';
 import { ExistingCodeMigration } from '../../duckling/migration/existing-code-migration';
@@ -9,8 +9,9 @@ import { MigrationTools } from '../../duckling/migration/migration-tools';
 import { ParsedMap } from '../../duckling/project/map-parser.service';
 import { EntitySystem, Entity, EntityKey } from '../../duckling/entitysystem/entity';
 
-const MIGRATION_FILE: ProjectVersionInfo = {
-    mapVersion: "1.0",
+const MIGRATION_FILE: VersionFile = {
+    projectVersion: "1.0",
+    editorVersion: "0.1",
     mapMigrations: [
         {
             type: "existing-code",
@@ -77,8 +78,9 @@ describe("MigrationService", function () {
 
     describe("updateVersionInfoWithExistingCodeMigration", () => {
 
-        const PRE_MIGRATION_VERSION_INFO : ProjectVersionInfo = {
-            mapVersion: "1.0",
+        const PRE_MIGRATION_VERSION_INFO : VersionFile = {
+            projectVersion: "1.0",
+            editorVersion: "0.1",
             mapMigrations: [
                 {
                     type: "code",
@@ -88,8 +90,9 @@ describe("MigrationService", function () {
             ]
         };
 
-        const EXPECTED_VERSION_INFO = {
-            mapVersion: "2.0",
+        const EXPECTED_VERSION_INFO : VersionFile = {
+            projectVersion: "2.0",
+            editorVersion: "0.1",            
             mapMigrations: [
                 {
                     type: "code",
@@ -108,7 +111,7 @@ describe("MigrationService", function () {
             ]
         };
 
-        let versionInfo: any;
+        let versionInfo: VersionFile;
 
         beforeEach(() => {
             versionInfo = Object.assign({}, PRE_MIGRATION_VERSION_INFO);
@@ -120,7 +123,7 @@ describe("MigrationService", function () {
 
         describe("the existing-code migration that it adds", () => {
             it("has an 'updateTo' equal to the new project version in the file", () => {
-                expect(versionInfo.mapMigrations[1].updateTo).to.eql(EXPECTED_VERSION_INFO.mapVersion);
+                expect(versionInfo.mapMigrations[1].updateTo).to.eql(EXPECTED_VERSION_INFO.projectVersion);
             });
 
             it("has the options that were provided", () => {
@@ -129,7 +132,7 @@ describe("MigrationService", function () {
         });
 
         it("increments the project version", () => {
-            expect(versionInfo.mapVersion).to.eql(EXPECTED_VERSION_INFO.mapVersion);
+            expect(versionInfo.projectVersion).to.eql(EXPECTED_VERSION_INFO.projectVersion);
         });
     });
 

--- a/src/duckling-tests/migration/existing-migration.spec.ts
+++ b/src/duckling-tests/migration/existing-migration.spec.ts
@@ -14,7 +14,6 @@ const MIGRATION_FILE: VersionFile = {
     editorVersion: "0.1",
     mapMigrations: [
         {
-            type: "existing-code",
             updateTo: "1.0",
             name: "fake-collision-migration",
             options: {
@@ -83,7 +82,6 @@ describe("MigrationService", function () {
             editorVersion: "0.1",
             mapMigrations: [
                 {
-                    type: "code",
                     updateTo: "1.0",
                     name: "migrations/coin-migration"
                 }
@@ -95,12 +93,10 @@ describe("MigrationService", function () {
             editorVersion: "0.1",            
             mapMigrations: [
                 {
-                    type: "code",
                     updateTo: "1.0",
                     name: "migrations/coin-migration"
                 },
                 {
-                    type: "existing-code",
                     updateTo: "2.0",
                     name: "collision",
                     options: {

--- a/src/duckling-tests/migration/map-migration.spec.ts
+++ b/src/duckling-tests/migration/map-migration.spec.ts
@@ -3,37 +3,30 @@ import {migrationsToRun, MapMigration} from '../../duckling/migration/map-migrat
 
 const MIGRATIONS : MapMigration [] = [
         {
-            type : "code",
             updateTo : "1.0",
             name : "skip"
         },
         {
-            type : "code",
             updateTo : "3.0",
             name : "3"
         },
         {
-            type : "code",
             updateTo : "4.0",
             name : "4.0"
         },
         {
-            type : "code",
             updateTo : "4.0",
             name : "4.0"
         },
         {
-            type : "code",
             updateTo : "2.0",
             name : "2"
         },
         {
-            type : "code",
             updateTo : "5.0",
             name : "5"
         },
         {
-            type : "code",
             updateTo : "6.0",
             name : "6"
         },
@@ -43,7 +36,6 @@ describe("migrationsToRun", function() {
     it("upgrading a single version only returns migrations for that jump", function() {
         expect(migrationsToRun("4.0", "5.0", MIGRATIONS)).to.eql([
             {
-                type : "code",
                 updateTo : "5.0",
                 name : "5"
             },
@@ -58,27 +50,22 @@ describe("migrationsToRun", function() {
     it("Can return multiple conversions", function() {
         expect(migrationsToRun("1.0", "5.0", MIGRATIONS)).to.eql([
             {
-                type : "code",
                 updateTo : "2.0",
                 name : "2"
             },
             {
-                type : "code",
                 updateTo : "3.0",
                 name : "3"
             },
             {
-                type : "code",
                 updateTo : "4.0",
                 name : "4.0"
             },
             {
-                type : "code",
                 updateTo : "4.0",
                 name : "4.0"
             },
             {
-                type : "code",
                 updateTo : "5.0",
                 name : "5"
             }]);

--- a/src/duckling-tests/migration/migration.service.spec.ts
+++ b/src/duckling-tests/migration/migration.service.spec.ts
@@ -9,37 +9,30 @@ const MIGRATION_FILE : VersionFile = {
     editorVersion: "0.1",
     mapMigrations : [
         {
-            type : "code",
             updateTo : "1.0",
             name : "skip1"
         },
         {
-            type : "code",
             updateTo : "3.0",
             name : "3.0"
         },
         {
-            type : "code",
             updateTo : "4.0",
             name : "4.0"
         },
         {
-            type : "code",
             updateTo : "4.0",
             name : "4.0"
         },
         {
-            type : "code",
             updateTo : "2.0",
             name : "2.0"
         },
         {
-            type : "code",
             updateTo : "5.0",
             name : "5.0"
         },
         {
-            type : "code",
             updateTo : "6.0",
             name : "skip6"
         },

--- a/src/duckling-tests/migration/migration.service.spec.ts
+++ b/src/duckling-tests/migration/migration.service.spec.ts
@@ -1,11 +1,12 @@
 import {expect} from 'chai';
 
-import {MigrationService, ProjectVersionInfo} from '../../duckling/migration/migration.service';
+import {MigrationService, VersionFile} from '../../duckling/migration/migration.service';
 import {PathService} from '../../duckling/util/path.service';
 import {ChangeType, changeType} from '../../duckling/state/object-diff';
 
-const MIGRATION_FILE : ProjectVersionInfo = {
-    mapVersion : "5.0",
+const MIGRATION_FILE : VersionFile = {
+    projectVersion : "5.0",
+    editorVersion: "0.1",
     mapMigrations : [
         {
             type : "code",

--- a/src/duckling-tests/project/map-parser.service.spec.ts
+++ b/src/duckling-tests/project/map-parser.service.spec.ts
@@ -15,7 +15,7 @@ import {immutableAssign, PathService} from '../../duckling/util';
 
 const MAP_VERSION = "1.0";
 const PROJECT_VERSION_INFO = {
-    mapVersion : MAP_VERSION
+    projectVersion : MAP_VERSION
 }
 
 let emptyMap : RawMapFile = {

--- a/src/duckling/migration/README.md
+++ b/src/duckling/migration/README.md
@@ -8,14 +8,12 @@ Your duckling project has a `project/version.json` file that describes the proje
     editorVersion : "0.1",
     migrations : [
         {
-            "type" : "code", // This indicates the migration is custom code written for the project.
             "updateTo" : "2.0", // Run the migration when updating maps to project version "2.0"
-            "name" : "migrations/make-collision100" // The migration script is {ProjectRoot}/project/migrations/make-collision100.js
+            "path" : "migrations/make-collision100" // The migration script is {ProjectRoot}/project/migrations/make-collision100.js
         },
         {
-            "type" : "code",
             "updateTo" : "3.0",
-            "name" : "migrations/add-drawable"
+            "path" : "migrations/add-drawable"
         }
     ]
 }

--- a/src/duckling/migration/existing-code-migration.ts
+++ b/src/duckling/migration/existing-code-migration.ts
@@ -1,0 +1,9 @@
+import {MapMigration} from './map-migration';
+import {MigrationTools} from './migration-tools';
+import {Attribute} from './map-format';
+import {MapMigrationFunction} from './migration.service';
+
+export interface ExistingCodeMigration {
+    function: (tools : MigrationTools) => MapMigrationFunction;
+    name: string;
+}

--- a/src/duckling/migration/existing-code-migration.ts
+++ b/src/duckling/migration/existing-code-migration.ts
@@ -1,10 +1,10 @@
-import {MapMigration} from './map-migration';
-import {MigrationTools} from './migration-tools';
-import {Attribute} from './map-format';
-import {MapMigrationFunction} from './migration.service';
+import { MapMigration } from './map-migration';
+import { MigrationTools } from './migration-tools';
+import { Attribute } from './map-format';
+import { MapMigrationFunction, EntitySystemMigrationFunction } from './migration.service';
 
 export interface ExistingCodeMigration {
-    rawMapFunction: (tools : MigrationTools) => MapMigrationFunction;
-    entitySystemFunction: () => MapMigrationFunction;
+    rawMapFunction: (tools: MigrationTools) => MapMigrationFunction;
+    entitySystemFunction: EntitySystemMigrationFunction;
     name: string;
 }

--- a/src/duckling/migration/existing-code-migration.ts
+++ b/src/duckling/migration/existing-code-migration.ts
@@ -4,6 +4,7 @@ import {Attribute} from './map-format';
 import {MapMigrationFunction} from './migration.service';
 
 export interface ExistingCodeMigration {
-    function: (tools : MigrationTools) => MapMigrationFunction;
+    rawMapFunction: (tools : MigrationTools) => MapMigrationFunction;
+    entitySystemFunction: () => MapMigrationFunction;
     name: string;
 }

--- a/src/duckling/migration/map-migration.ts
+++ b/src/duckling/migration/map-migration.ts
@@ -3,9 +3,9 @@ import {MapVersion, compareVersions, versionCompareFunction, VersionCompatibilit
  * Represents a single migration that needs to be run when updating to the specified version.
  */
 export interface MapMigration {
-    type : "code" | "editor-version" | "existing-code", // "editor-version" is really "engine-version"
     updateTo : MapVersion;
-    name : string; // "migrations/updatecoins" or "2"
+    name?: string; // e.g. "ExistingCodeMigration.EditCollisionTypes" 
+    path?: string; // e.g. "migrations/updatecoins"
     options? : any;
 }
 

--- a/src/duckling/migration/map-migration.ts
+++ b/src/duckling/migration/map-migration.ts
@@ -3,7 +3,7 @@ import {MapVersion, compareVersions, versionCompareFunction, VersionCompatibilit
  * Represents a single migration that needs to be run when updating to the specified version.
  */
 export interface MapMigration {
-    type : "code" | "editor-version"; // | "editor-built-in",
+    type : "code" | "editor-version" | "existing-code", // "editor-version" is really "engine-version"
     updateTo : MapVersion;
     name : string; // "migrations/updatecoins" or "2"
     options? : any;

--- a/src/duckling/migration/migration-tools.ts
+++ b/src/duckling/migration/migration-tools.ts
@@ -1,11 +1,11 @@
 import {Attribute, Map, System, Components} from './map-format';
 
 interface AttributeMigration {
-    (attribute : Attribute) : Attribute;
+    (attribute : Attribute, options?: any) : Attribute;
 }
 
 interface EntityMigration {
-    (entity : Entity, entityKey: string) : Entity;
+    (entity : Entity, entityKey: string, options?: any) : Entity;
 }
 
 interface MigrationTest {
@@ -36,18 +36,18 @@ export class MigrationTools {
      * @return A migration that runs over a map.
      */
     attributeMigration(systemName : string, migration : AttributeMigration) {
-        return (map : Map) : Map => {
+        return (map : Map, options?: any) : Map => {
             if (!map.systems[systemName]) {
                 return map;
             }
 
             let newComponents : Components = {};
             let oldComponents : Components = map.systems[systemName].components;
-            for (let attributeKey in oldComponents)
+            for (let entityKey in oldComponents)
             {
-                let migratedAttribute = migration(oldComponents[attributeKey]);
+                let migratedAttribute = migration(oldComponents[entityKey], options);
                 if (migratedAttribute) {
-                    newComponents[attributeKey] = migratedAttribute;
+                    newComponents[entityKey] = migratedAttribute;
                 }
             }
             let newSystem: System = {...map.systems[systemName], components : newComponents};
@@ -76,10 +76,10 @@ export class MigrationTools {
      * @return a migration that runs over a map.
      */
     entityMigration(entityMigration : EntityMigration) {
-        return (map : Map) : Map => {
+        return (map : Map, options?: any) : Map => {
             let systems : {[systemName : string] : System} = {};
             for (let entityKey of map.entities) {
-                let migratedEntity = entityMigration(this.getEntity(map, entityKey), entityKey);
+                let migratedEntity = entityMigration(this.getEntity(map, entityKey), entityKey, options);
                 for (let systemKey in migratedEntity) {
 
                     if (!systems[systemKey]) {

--- a/src/duckling/migration/migration.service.ts
+++ b/src/duckling/migration/migration.service.ts
@@ -115,6 +115,11 @@ export class MigrationService {
         }
     }
 
+    async saveProject(projectPath: string, versionInfo: VersionFile): Promise<any> {
+        let versionFileName = this._path.join(projectPath, "project", "version.json");
+        await this._jsonLoader.saveJsonToPath(versionFileName, JSON.stringify(versionInfo,null, 4));
+    }
+
     private async _addMissingEditorMigrations(versionFile: VersionFile, missingMigrations: EditorMigration[], versionFileName: string) {
         missingMigrations.sort((a, b) => versionCompareFunction(a.updateEditorVersion, b.updateEditorVersion));
         for (let migration of missingMigrations) {

--- a/src/duckling/migration/migration.service.ts
+++ b/src/duckling/migration/migration.service.ts
@@ -34,7 +34,7 @@ export class MigrationService {
     /**
      * Migrate a map to the newest version supported by the editor. Throws if the map is more advanced than the editor supports.
      */
-    async migrateMap<T>(map: T, versionInfo: ProjectVersionInfo, migrationRoot: string): Promise<T> {
+    async migrateMap(map: any, versionInfo: ProjectVersionInfo, migrationRoot: string): Promise<any> {
         let mapVersion = (map as any).version;
 
         if (versionCompareFunction(versionInfo.mapVersion, mapVersion) < 0) {
@@ -55,6 +55,7 @@ export class MigrationService {
 
         return Promise.resolve(result);
     }
+
 
     /**
      * Get project migration data and run any migrations that need to be run immediatly.
@@ -150,7 +151,7 @@ export class MigrationService {
     }
 
     private _loadExistingCodeMigration(migration: MapMigration): MapMigrationFunction {
-        return this._existingCodeMigrations[migration.name].function(new MigrationTools());
+        return this._existingCodeMigrations[migration.name].rawFunction(new MigrationTools());
     }
 }
 

--- a/src/duckling/migration/migration.service.ts
+++ b/src/duckling/migration/migration.service.ts
@@ -116,7 +116,7 @@ export class MigrationService {
     }
 
     async saveProject(projectPath: string, versionInfo: VersionFile): Promise<any> {
-        let versionFileName = this._path.join(projectPath, "project", "version.json");
+        let versionFileName = this._path.join(projectPath, "version.json");
         await this._jsonLoader.saveJsonToPath(versionFileName, JSON.stringify(versionInfo,null, 4));
     }
 

--- a/src/duckling/migration/migration.service.ts
+++ b/src/duckling/migration/migration.service.ts
@@ -34,17 +34,17 @@ export class MigrationService {
         this._existingCodeMigrations[existingCodeMigration.name] = existingCodeMigration;
     }
 
-    updateVersionFileWithExistingCodeMigration(versionFile: any, name: string, options?: any): any {
-        versionFile.projectVersion = incrementMajorVersion(versionFile.projectVersion);
-        versionFile.mapMigrations.push(
+    updateVersionInfoWithExistingCodeMigration(versionInfo: ProjectVersionInfo, name: string, options?: any): any {
+        versionInfo.mapVersion = incrementMajorVersion(versionInfo.mapVersion);
+        versionInfo.mapMigrations.push(
             {
                 type: "existing-code",
-                updateTo: versionFile.projectVersion,
+                updateTo: versionInfo.mapVersion,
                 name,
                 options
             }
         );
-        return versionFile;
+        return versionInfo;
     }
 
     migrateEntitySystem(entitySystem: EntitySystem, migrationName: string, options?: any): EntitySystem {
@@ -193,7 +193,7 @@ export interface EntitySystemMigrationFunction {
 }
 
 interface ProjectMigrationFunction {
-    async(): Promise<void>;
+    async (): Promise<void>;
 }
 
 interface VersionFile {

--- a/src/duckling/project/project.service.ts
+++ b/src/duckling/project/project.service.ts
@@ -114,20 +114,16 @@ export class ProjectService {
             ...this._project.currentMap
         }, this._project.versionInfo);
         let json = JSON.stringify(map, null, 4);
+        await this._migrationService.saveProject(this.projectMetaDataDir, this.project.value.versionInfo);     
         await this._saveProjectMetaData();
         await this._saveUserMetaData(this.project.value.userMetaData);
         await this._jsonLoader.saveJsonToPath(this.getMapPath(this._project.currentMap.key), json);
+
         this._snackbar.invokeSnacks();
     }
 
     private async _saveProjectMetaData() {
-        await this._saveProjectVersionInfo();
         await this._saveCustomAttributes();
-    }
-
-    private async _saveProjectVersionInfo() {
-
-
     }
 
     private async _saveCustomAttributes() {

--- a/src/duckling/project/project.service.ts
+++ b/src/duckling/project/project.service.ts
@@ -255,11 +255,11 @@ export class ProjectService {
     }
 
     async runExistingCodeMigration(migrationName: string, options: any): Promise<void> {
-        this._updateProjectVersionInfo(migrationName, options);
-        this._updateEntitySystemWithExistingCodeMigration(migrationName, options);
+        this._addMigrationToVersionInfo(migrationName, options);
+        this._runMigrationOnOpenMap(migrationName, options);
     }
 
-    private _updateProjectVersionInfo(migrationName: string, options?: any) {
+    private _addMigrationToVersionInfo(migrationName: string, options?: any) {
         let newVersionInfo = this._migrationService.updateVersionInfoWithExistingCodeMigration(
             this.project.value.versionInfo,
             migrationName,
@@ -267,14 +267,14 @@ export class ProjectService {
         this._storeService.dispatch(setVersionInfo(newVersionInfo));
     }
 
-    private _updateEntitySystemWithExistingCodeMigration(migrationName: string, options: any) {
+    private _runMigrationOnOpenMap(migrationName: string, options: any) {
         let newEntitySystem = this._migrationService.migrateEntitySystem(
             this._entitySystem.entitySystem.value,
             migrationName,
             options);
         this._storeService.dispatch(replaceSystemAction(newEntitySystem));
     }
-    
+
     async saveVersionFile(versionFileContents: any): Promise<SaveResult> {
         let json = JSON.stringify(versionFileContents, null, 4);
         return this._jsonLoader.saveJsonToPath(this._pathService.join(this.projectMetaDataDir, "version.json"), json);

--- a/src/duckling/project/project.service.ts
+++ b/src/duckling/project/project.service.ts
@@ -285,8 +285,9 @@ export class ProjectService {
         return versionFile;
     }
 
-    async saveVersionFile(versionFileJSON: any): Promise<SaveResult> {
-        return this._jsonLoader.saveJsonToPath(this._pathService.join(this.projectMetaDataDir, "version.json"), versionFileJSON);
+    async saveVersionFile(versionFileContents: any): Promise<SaveResult> {
+        let json = JSON.stringify(versionFileContents, null, 4);
+        return this._jsonLoader.saveJsonToPath(this._pathService.join(this.projectMetaDataDir, "version.json"), json);
     }
 
     private async _parseMapJson(json: any, key: string) {

--- a/src/duckling/project/project.service.ts
+++ b/src/duckling/project/project.service.ts
@@ -274,19 +274,7 @@ export class ProjectService {
             options);
         this._storeService.dispatch(replaceSystemAction(newEntitySystem));
     }
-
-    async openVersionFile(): Promise<any> {
-        let versionFileName = this._pathService.join(this.projectMetaDataDir, "version.json");
-        let rawFile = await this._jsonLoader.getJsonFromPath(versionFileName);
-        let versionFile;
-        try {
-            versionFile = JSON.parse(rawFile);
-        } catch (exception) {
-            rethrow(`Error loading "project/version.js"`, exception);
-        }
-        return versionFile;
-    }
-
+    
     async saveVersionFile(versionFileContents: any): Promise<SaveResult> {
         let json = JSON.stringify(versionFileContents, null, 4);
         return this._jsonLoader.saveJsonToPath(this._pathService.join(this.projectMetaDataDir, "version.json"), json);

--- a/src/duckling/project/project.service.ts
+++ b/src/duckling/project/project.service.ts
@@ -13,7 +13,7 @@ import { DialogService } from '../util/dialog.service';
 import { glob } from '../util/glob';
 import { JsonSchema } from '../util/json-schema';
 import { Vector } from '../math/vector';
-import { MigrationService, ProjectVersionInfo } from '../migration/migration.service';
+import { MigrationService, VersionFile } from '../migration/migration.service';
 import { incrementMajorVersion, compareVersions, EDITOR_VERSION } from '../util/version';
 import { replaceSystemAction } from '../entitysystem/entity-system.reducer';
 
@@ -121,7 +121,13 @@ export class ProjectService {
     }
 
     private async _saveProjectMetaData() {
+        await this._saveProjectVersionInfo();
         await this._saveCustomAttributes();
+    }
+
+    private async _saveProjectVersionInfo() {
+
+
     }
 
     private async _saveCustomAttributes() {
@@ -291,17 +297,17 @@ export class ProjectService {
     }
 
     private async _parseMapJson(json: any, key: string) {
-        let rawMap = json ? JSON.parse(json) : createRawMap(this._project.versionInfo.mapVersion);
+        let rawMap = json ? JSON.parse(json) : createRawMap(this._project.versionInfo.projectVersion);
         rawMap = await this._migrationService.migrateMap(rawMap, this._project.versionInfo, this.projectMetaDataDir);
 
         let parsedMap = await this._mapParser.rawMapToParsedMap(rawMap);
 
         this._entitySystem.replaceSystem(parsedMap.entitySystem);
         if (!parsedMap.dimension) {
-            parsedMap = immutableAssign(parsedMap, createRawMap(this._project.versionInfo.mapVersion));
+            parsedMap = immutableAssign(parsedMap, createRawMap(this._project.versionInfo.projectVersion));
         }
         if (!parsedMap.gridSize) {
-            parsedMap = immutableAssign(parsedMap, createRawMap(this._project.versionInfo.mapVersion));
+            parsedMap = immutableAssign(parsedMap, createRawMap(this._project.versionInfo.projectVersion));
         }
 
         this._storeService.dispatch(openMapAction({

--- a/src/duckling/project/project.ts
+++ b/src/duckling/project/project.ts
@@ -1,9 +1,9 @@
-import {Action} from '../state';
-import {AttributeKey} from '../entitysystem/entity';
-import {immutableAssign} from '../util';
-import {Vector} from '../math/vector';
-import {MapVersion} from '../util/version';
-import {ProjectVersionInfo} from '../migration/migration.service';
+import { Action } from '../state';
+import { AttributeKey } from '../entitysystem/entity';
+import { immutableAssign } from '../util';
+import { Vector } from '../math/vector';
+import { MapVersion } from '../util/version';
+import { VersionFile } from '../migration/migration.service';
 
 import {CustomAttribute} from './custom-attribute';
 import {UserMetaData, userMetaDataReducer} from './user-meta-data';
@@ -22,9 +22,9 @@ export interface Project {
     home? : string,
     loaded? : boolean,
     currentMap? : ProjectMap,
-    versionInfo? : ProjectVersionInfo,
+    versionInfo? : VersionFile,
     userMetaData : UserMetaData
-    customAttributes : CustomAttribute[],
+    customAttributes : CustomAttribute[]
 }
 
 /**
@@ -32,17 +32,18 @@ export interface Project {
  * @param  home The home path of the project.
  * @return An action that can be dispatched to switch the project.
  */
-export function switchProjectAction(home : string) : SwitchProjectAction {
+export function switchProjectAction(home: string): SwitchProjectAction {
     return {
-        type : ACTION_SWITCH_PROJECT,
+        type: ACTION_SWITCH_PROJECT,
         home
     }
 }
 
 const ACTION_SWITCH_PROJECT = "Project.Switch";
 interface SwitchProjectAction extends Action {
-    home : string,
+    home: string,
 }
+
 function _switchProject(project : Project, action : SwitchProjectAction) : Project {
     return {
         ...project,
@@ -53,14 +54,14 @@ function _switchProject(project : Project, action : SwitchProjectAction) : Proje
 
 const ACTION_SET_VERSION = "Project.SetVersion";
 interface SetVersionAction extends Action {
-    type : "Project.SetVersion",
-    version : ProjectVersionInfo
+    type: "Project.SetVersion",
+    version: VersionFile
 }
-function _setMapVersion(project : Project, action : SetVersionAction) : Project {
-    return {...project, versionInfo: action.version}
+function _setMapVersion(project: Project, action: SetVersionAction): Project {
+    return { ...project, versionInfo: action.version }
 }
-export function setVersionInfo(version : ProjectVersionInfo) {
-    return {type : ACTION_SET_VERSION, version};
+export function setVersionInfo(version: VersionFile) {
+    return { type: ACTION_SET_VERSION, version };
 }
 
 /**
@@ -68,7 +69,7 @@ export function setVersionInfo(version : ProjectVersionInfo) {
  * used once the load is finished.
  * @param  mapName The name of the current map.
  */
-export function openMapAction(map : ProjectMap) {
+export function openMapAction(map: ProjectMap) {
     return {
         type: ACTION_OPEN_MAP,
         map: map
@@ -83,15 +84,15 @@ interface OpenMapAction extends Action {
         gridSize: number
     }
 }
-function _openMap(project : Project, action : OpenMapAction) {
-    return immutableAssign(project, {currentMap : action.map, loaded : false});
+function _openMap(project: Project, action: OpenMapAction) {
+    return immutableAssign(project, { currentMap: action.map, loaded: false });
 }
 
 /**
  * Create an action that changes the dimension of the current map.
  * @param newDimension The new dimensions of the map
  */
-export function changeCurrentMapDimensionAction(newDimension : Vector) {
+export function changeCurrentMapDimensionAction(newDimension: Vector) {
     return {
         type: ACTION_CHANGE_MAP_DIMENSION,
         newDimension: newDimension
@@ -101,16 +102,16 @@ export const ACTION_CHANGE_MAP_DIMENSION = "Project.ChangeCurrentMapDimension";
 interface ChangeCurrentMapDimensionAction extends Action {
     newDimension: Vector
 }
-function _changeCurrentMapDimension(project : Project, action : ChangeCurrentMapDimensionAction) {
-    let map = immutableAssign(project.currentMap, {dimension: action.newDimension});
-    return immutableAssign(project, {currentMap : map});
+function _changeCurrentMapDimension(project: Project, action: ChangeCurrentMapDimensionAction) {
+    let map = immutableAssign(project.currentMap, { dimension: action.newDimension });
+    return immutableAssign(project, { currentMap: map });
 }
 
 /**
  * Create an action that changes the grid size of the current map.
  * @param newGridSize The new grid size of the map
  */
-export function changeCurrentMapGridAction(newGridSize : number) {
+export function changeCurrentMapGridAction(newGridSize: number) {
     return {
         type: ACTION_CHANGE_MAP_GRID,
         newGridSize: newGridSize
@@ -120,9 +121,9 @@ export const ACTION_CHANGE_MAP_GRID = "Project.ChangeCurrentMapGrid";
 interface ChangeCurrentMapGridAction extends Action {
     newGridSize: number
 }
-function _changeCurrentMapGrid(project : Project, action : ChangeCurrentMapGridAction) {
-    let map = immutableAssign(project.currentMap, {gridSize: action.newGridSize});
-    return immutableAssign(project, {currentMap : map});
+function _changeCurrentMapGrid(project: Project, action: ChangeCurrentMapGridAction) {
+    let map = immutableAssign(project.currentMap, { gridSize: action.newGridSize });
+    return immutableAssign(project, { currentMap: map });
 }
 
 /**
@@ -130,7 +131,7 @@ function _changeCurrentMapGrid(project : Project, action : ChangeCurrentMapGridA
  */
 export function doneLoadingProjectAction() {
     return {
-        type : ACTION_DONE_LOADING
+        type: ACTION_DONE_LOADING
     }
 }
 const ACTION_DONE_LOADING = "Project.DoneLoading";
@@ -139,7 +140,7 @@ const ACTION_DONE_LOADING = "Project.DoneLoading";
  * Create an action that changes the custom attributes of the project
  * @param newCustomAttributes The new custom attributes for the project
  */
-export function changeCustomAttributes(newCustomAttributes : CustomAttribute[]) {
+export function changeCustomAttributes(newCustomAttributes: CustomAttribute[]) {
     return {
         type: ACTION_CHANGE_CUSTOM_ATTRIBUTES,
         newCustomAttributes
@@ -149,8 +150,8 @@ export const ACTION_CHANGE_CUSTOM_ATTRIBUTES = "Project.ChangeCustomAttributes";
 interface ChangeCustomAttributesAction extends Action {
     newCustomAttributes: CustomAttribute[]
 }
-function _changeCustomAttributes(project : Project, action : ChangeCustomAttributesAction) {
-    return immutableAssign(project, {customAttributes : action.newCustomAttributes});
+function _changeCustomAttributes(project: Project, action: ChangeCustomAttributesAction) {
+    return immutableAssign(project, { customAttributes: action.newCustomAttributes });
 }
 
 /**


### PR DESCRIPTION
Added functions to run migrations within the editor (#314)

https://github.com/ild-games/duckling/issues/314

* In project.service
  - runExistingCodeMigration
  - openVersionFile
* In migration.service
  - updateVersionFileWithExistingCodeMigration
  - migrateEntitySystem
  - introduced a new type of MapMigration