### PR TITLE
Allow collision types to be edited and deleted

### DIFF
--- a/src/duckling/controls/edit-input.component.ts
+++ b/src/duckling/controls/edit-input.component.ts
@@ -20,6 +20,7 @@ import {DeleteButtonComponent, InputComponent} from '../controls';
             <div *ngIf="!isEditingValue" class="edit-label">
                 <dk-inline-edit-label
                     [label]="labelAndValue"
+                    [floatIconRight]="floatIconRight"
                     [tooltip]="editTooltip"
                     (startEdit)="onBeginEdit()">
                 </dk-inline-edit-label>
@@ -50,6 +51,7 @@ export class EditInputComponent implements OnChanges, OnInit {
     @Input() editTooltip : string;
     @Input() validTooltip : string;
     @Input() invalidTooltip : string;
+    @Input() floatIconRight : boolean;
     @Output() onValueSaved = new EventEmitter<string>();
 
     editValue : string;

--- a/src/duckling/controls/edit-input.component.ts
+++ b/src/duckling/controls/edit-input.component.ts
@@ -19,14 +19,14 @@ import {DeleteButtonComponent, InputComponent} from '../controls';
         <div class="container">
             <div *ngIf="!isEditingValue" class="edit-label">
                 <dk-inline-edit-label
-                    label="{{label}}: {{value}}"
+                    [label]="labelAndValue"
                     [tooltip]="editTooltip"
                     (startEdit)="onBeginEdit()">
                 </dk-inline-edit-label>
             </div>
             
             <div *ngIf="isEditingValue" class="edit-label">
-                <span class="edit-label-text">{{label}}:</span>
+                <span class="edit-label-text">{{editLabel}}</span>
                 <dk-input
                     [value]="editValue"
                     [dividerColor]="isValid ? 'primary' : 'warn'"
@@ -97,5 +97,19 @@ export class EditInputComponent implements OnChanges, OnInit {
         }
 
         return this.validator(this.editValue);
+    }
+
+    get labelAndValue() : string {
+        if (this.label) {
+            return `${this.label}: ${this.value}`;
+        }
+        return this.value;
+    }
+
+    get editLabel() : string {
+        if (this.label) {
+            return `${this.label}:`;
+        }
+        return "";
     }
 }

--- a/src/duckling/controls/inline-edit-label.component.scss
+++ b/src/duckling/controls/inline-edit-label.component.scss
@@ -1,6 +1,7 @@
 :host {
     display: flex;
     align-items: center;
+    width: 100%;
 }
 
 div {
@@ -8,4 +9,8 @@ div {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+}
+
+dk-icon-button.float-icon-right {
+    margin-left: auto;
 }

--- a/src/duckling/controls/inline-edit-label.component.ts
+++ b/src/duckling/controls/inline-edit-label.component.ts
@@ -12,6 +12,7 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
         </div>
         <dk-icon-button
             icon="pencil"
+            [class]="iconClasses"
             [tooltip]="tooltip"
             (click)="onEditClicked()">
         </dk-icon-button>
@@ -27,6 +28,7 @@ export class InlineEditLabelComponent {
      * Tootlip the user sees when they hover over the pencil.
      */
     @Input() tooltip : string;
+    @Input() floatIconRight : boolean;
 
     /**
      * Event that fires when the user clicks on the pencil to start editing the value.
@@ -35,5 +37,12 @@ export class InlineEditLabelComponent {
 
     onEditClicked() {
         this.startEdit.emit(true);
+    }
+
+    get iconClasses() : string {
+        if (this.floatIconRight) {
+            return "float-icon-right";
+        }
+        return "";
     }
 }

--- a/src/duckling/game/collision/collision-migration.ts
+++ b/src/duckling/game/collision/collision-migration.ts
@@ -1,0 +1,33 @@
+import {Map} from 'immutable';
+
+import {ExistingCodeMigration} from '../../migration/existing-code-migration';
+import {MigrationTools} from '../../migration/migration-tools';
+import {EntitySystem, Entity, EntityKey} from '../../entitysystem/entity';
+
+import {COLLISION_KEY} from './collision-attribute';
+
+export const EDIT_COLLISION_TYPE_MIGRATION_NAME = "ExistingCodeMigration.EditCollisionTypes";
+
+export let editCollisionTypeMigration : ExistingCodeMigration = {
+    rawMapFunction: (tools : MigrationTools) => {
+        return tools.attributeMigration("collision", (attribute: any, options: any) => {
+            if (attribute.collisionType === options.oldType) {
+                attribute.collisionType = options.newType;
+            }
+            return attribute;
+        });
+    },
+    entitySystemFunction: (entitySystem : EntitySystem, options? : any) => {
+        return entitySystem.map((entity: Entity) => {
+            for (let attributeKey in entity) {
+                if (attributeKey === COLLISION_KEY) {
+                    if ((entity.collision as any).collisionType === options.oldType) {
+                        (entity[attributeKey] as any).collisionType = options.newType;
+                    }
+                }
+            }
+            return entity;
+        }) as Map<EntityKey, Entity>;
+    },
+    name: EDIT_COLLISION_TYPE_MIGRATION_NAME
+};

--- a/src/duckling/game/collision/collision-types.service.ts
+++ b/src/duckling/game/collision/collision-types.service.ts
@@ -67,6 +67,19 @@ export class CollisionTypesService {
         this._registerCollisionTypes([collisionType]);
     }
 
+    editCollisionType(oldValue : string, newValue : string) {
+        if (!this.collisionTypes.value.has(oldValue)) {
+            throw new Error(`Attempt to edit collision type that is not registered: ${oldValue}`);
+        }
+        let newCollisionTypes = Array.from(this.collisionTypes.value.values());
+        for (let i = 0; i < newCollisionTypes.length; i++) {
+            if (newCollisionTypes[i] === oldValue) {
+                newCollisionTypes[i] = newValue;
+            }
+        }
+        this._store.dispatch(_collisionTypesAction(new Set<string>(newCollisionTypes)));
+    }
+
     private _registerAnconaCollisionTypes(collisionTypeMetaData : CollisionTypeMetaData) {
         let collisionTypes = [NONE_COLLISION_TYPE];
         if (collisionTypeMetaData) {

--- a/src/duckling/game/collision/collision-types.service.ts
+++ b/src/duckling/game/collision/collision-types.service.ts
@@ -80,6 +80,15 @@ export class CollisionTypesService {
         this._store.dispatch(_collisionTypesAction(new Set<string>(newCollisionTypes)));
     }
 
+    removeCollisionType(collisionType : string) {
+        if (!this.collisionTypes.value.has(collisionType)) {
+            throw new Error(`Attempt to delete collision type that is not registered: ${collisionType}`);
+        }
+        let newCollisionTypes = new Set<string>(this.collisionTypes.value);
+        newCollisionTypes.delete(collisionType);
+        this._store.dispatch(_collisionTypesAction(new Set<string>(newCollisionTypes)));
+    }
+
     private _registerAnconaCollisionTypes(collisionTypeMetaData : CollisionTypeMetaData) {
         let collisionTypes = [NONE_COLLISION_TYPE];
         if (collisionTypeMetaData) {

--- a/src/duckling/game/collision/edit-collision-types.component.scss
+++ b/src/duckling/game/collision/edit-collision-types.component.scss
@@ -2,3 +2,7 @@
     max-height: 350px;
     overflow: auto;
 }
+
+.edit-input {
+    margin-left: auto;
+}

--- a/src/duckling/game/collision/edit-collision-types.component.scss
+++ b/src/duckling/game/collision/edit-collision-types.component.scss
@@ -1,8 +1,17 @@
 .current-collision-types {
     max-height: 350px;
     overflow: auto;
-}
 
-.edit-input {
-    margin-left: auto;
+    div {
+        display: flex;
+
+        dk-edit-input {
+            flex: 1 1 auto;
+        }
+
+        dk-delete-button {
+            flex: 0 0 auto;
+            align-self: center;
+        }
+    }
 }

--- a/src/duckling/game/collision/edit-collision-types.component.ts
+++ b/src/duckling/game/collision/edit-collision-types.component.ts
@@ -40,6 +40,7 @@ import {EDIT_COLLISION_TYPE_MIGRATION_NAME} from './collision-migration';
                     *ngFor="let collisionType of collisionTypes"
                     [value]="collisionType"
                     [validator]="collisionTypeValidator(collisionType)"
+                    [floatIconRight]="true"
                     editTooltip="Edit collision type"
                     validTooltip="Save collision type"
                     invalidTooltip="Collision type cannot be a duplicate or blank"

--- a/src/duckling/game/collision/edit-collision-types.component.ts
+++ b/src/duckling/game/collision/edit-collision-types.component.ts
@@ -4,8 +4,10 @@ import {Observable} from 'rxjs';
 
 import {StoreService} from '../../state/store.service';
 import {ProjectService} from '../../project/project.service';
+import {Validator} from '../../controls/validated-input.component';
 
 import {CollisionTypesService} from './collision-types.service';
+import {EDIT_COLLISION_TYPE_MIGRATION_NAME} from './collision-migration';
 
 /**
  * Dialog to allow the user to manager their collision types
@@ -34,10 +36,15 @@ import {CollisionTypesService} from './collision-types.service';
         </dk-section>
         <dk-section headerText="Current Collision Types">
             <mat-list class="current-collision-types">
-                <mat-list-item
-                    *ngFor="let collisionType of collisionTypes">
-                    {{collisionType}}
-                </mat-list-item>
+                <dk-edit-input
+                    *ngFor="let collisionType of collisionTypes"
+                    [value]="collisionType"
+                    [validator]="collisionTypeValidator(collisionType)"
+                    editTooltip="Edit collision type"
+                    validTooltip="Save collision type"
+                    invalidTooltip="Collision type cannot be a duplicate or blank"
+                    (onValueSaved)="onCollisionTypeModified(collisionType, $event)">
+                </dk-edit-input>
             </mat-list>
         </dk-section>
     `
@@ -48,7 +55,8 @@ export class EditCollisionTypesComponent {
 
     constructor(private _collisionTypes : CollisionTypesService,
                 private _storeService : StoreService,
-                private _dialogRef : MatDialogRef<EditCollisionTypesComponent>) {
+                private _dialogRef : MatDialogRef<EditCollisionTypesComponent>,
+                private _projectService : ProjectService) {
     }
 
     createCollisionType() {
@@ -57,11 +65,35 @@ export class EditCollisionTypesComponent {
         }
     }
 
-    newCollisionTypeIsValid() {
+    newCollisionTypeIsValid() : boolean {
         return this.newCollisionType !== "" && this.collisionTypes.indexOf(this.newCollisionType) === -1;
+    }
+
+    onCollisionTypeModified(oldValue : string, newValue : string) {
+        this._collisionTypes.editCollisionType(oldValue, newValue);
+        this._projectService.runExistingCodeMigration(
+            EDIT_COLLISION_TYPE_MIGRATION_NAME, 
+            {
+                oldType: oldValue, 
+                newType: newValue
+            });
     }
 
     get collisionTypes() : string[] {
         return Array.from(this._collisionTypes.collisionTypes.getValue().values());
     }
+
+    collisionTypeValidator(currentEditingType : string) : Validator {
+        return (value : string) => {
+            if (!value || value === "") {
+                return false;
+            }
+            if (value === currentEditingType) {
+                return true;
+            }
+
+            return this.collisionTypes.indexOf(value) === -1;
+        }
+    }
 }
+

--- a/src/duckling/game/game.module.ts
+++ b/src/duckling/game/game.module.ts
@@ -35,6 +35,7 @@ import {GenericShapeComponent} from './drawable/generic-shape.component';
 
 import {CollisionTypesService} from './collision/collision-types.service';
 import {EditCollisionTypesComponent} from './collision/edit-collision-types.component';
+import {editCollisionTypeMigration} from './collision/collision-migration';
 
 import {
     AttributeDefaultService,
@@ -47,6 +48,7 @@ import {AttributeComponentService} from '../entityeditor';
 import {EntityDrawerService} from '../canvas/drawing/entity-drawer.service';
 import {RequiredAssetService} from '../project';
 import {ProjectLifecycleService} from '../project/project-lifecycle.service';
+import {MigrationService} from '../migration/migration.service';
 
 import {bootstrapGameComponents} from './index';
 
@@ -109,9 +111,11 @@ export class GameModule {
                 public requiredAssetService : RequiredAssetService,
                 public entityLayerService : EntityLayerService,
                 private _collisionTypesService : CollisionTypesService,
-                private _projectLifecycleService : ProjectLifecycleService) {
+                private _projectLifecycleService : ProjectLifecycleService,
+                private _migrationService : MigrationService) {
         bootstrapGameComponents(this);
         this._bootstrapLifecycle();
+        this._registerExistingCodeMigrations();
     }
 
     private _bootstrapLifecycle() {
@@ -125,5 +129,9 @@ export class GameModule {
 
     private _bootstrapBeforeMapSaveLifecycle() {
         this._projectLifecycleService.addPreSaveMapHook(map => this._collisionTypesService.preSaveMapHook(map));
+    }
+
+    private _registerExistingCodeMigrations() {
+        this._migrationService.registerExistingCodeMigration(editCollisionTypeMigration);
     }
 }


### PR DESCRIPTION
Resolves #317
**Commit message:**
Allow for collision types to be edited and deleted

`https://github.com/ild-games/duckling/issues/317`

Because modifying the collision types required modifying all maps, we needed infrastructure in place to allow for those types of migrations. Now that they are in this implements those changes.