### PR TITLE
don't attempt an attribute migration when the attribute doesn't exist…

### DIFF
--- a/src/duckling/migration/migration-tools.ts
+++ b/src/duckling/migration/migration-tools.ts
@@ -37,6 +37,10 @@ export class MigrationTools {
      */
     attributeMigration(systemName : string, migration : AttributeMigration) {
         return (map : Map) : Map => {
+            if (!map.systems[systemName]) {
+                return map;
+            }
+
             let newComponents : Components = {};
             let oldComponents : Components = map.systems[systemName].components;
             for (let attributeKey in oldComponents)


### PR DESCRIPTION
Resolves #335 
**Commit message:**
Don't run an attribute migration for an attribute that doesn't exist on the map. 

`https://github.com/ild-games/duckling/issues/335`

If the attribute didn't exist on a map that was having an attribute migration for that attribute run over it then duckling would throw a migration error up.