### PR TITLE
Various entity / attribute creation workflow enhancements

### DIFF
--- a/src/duckling/canvas/tools/entity-creator-tool.ts
+++ b/src/duckling/canvas/tools/entity-creator-tool.ts
@@ -16,10 +16,12 @@ import {newMergeKey} from '../../state';
 import {BaseTool, CanvasMouseEvent} from './base-tool';
 import {drawRectangle} from '../drawing';
 import {DrawnConstruct} from '../drawing/drawn-construct';
+import { AttributeDefaultAugmentationService } from '../../entitysystem/services/attribute-default-augmentation.service';
 
 @Injectable()
 export class EntityCreatorTool extends BaseTool {
     constructor(private _attributeDefaultService : AttributeDefaultService,
+                private _attributeDefaultAugmentationService : AttributeDefaultAugmentationService,
                 private _entitySystemService : EntitySystemService,
                 private _entityPositionService : EntityPositionService,
                 private _entityBoxService : EntityBoxService,
@@ -52,6 +54,8 @@ export class EntityCreatorTool extends BaseTool {
         let entity = this._attributeDefaultService.createEntity();
         entity = this._entityPositionService.setPosition(entity, event.stageCoords);
         let key = this._entitySystemService.addNewEntity(entity, mergeKey);
+        entity = this._attributeDefaultAugmentationService.augmentEntity({entity, key});
+        this._entitySystemService.updateEntity(key, entity, mergeKey);
         this._selection.deselect(mergeKey);
         this._selection.select([key], mergeKey);
     }

--- a/src/duckling/entitysystem/entity-system.module.ts
+++ b/src/duckling/entitysystem/entity-system.module.ts
@@ -11,12 +11,14 @@ import {
     EntityLayerService
 } from './index';
 import {LayerDialogComponent} from './services/layer-dialog.component';
+import { AttributeDefaultAugmentationService } from './services/attribute-default-augmentation.service';
 
 @NgModule({
     providers: [
-        AttributeDefaultService,
         AvailableAttributeService,
         EntityBoxService,
+        AttributeDefaultService,
+        AttributeDefaultAugmentationService,
         EntityPositionService,
         EntityLayerService,
         BaseAttributeService,

--- a/src/duckling/entitysystem/entity.ts
+++ b/src/duckling/entitysystem/entity.ts
@@ -6,7 +6,6 @@ export type Attribute = Object;
 export type AttributeKey = string;
 export type Entity = {[key:string]:Attribute};
 export type EntityKey = string;
-
 export type EntitySystem = Map<EntityKey,Entity>;
 
 export function createEntitySystem() : EntitySystem {
@@ -51,4 +50,3 @@ export function attributeDisplayName(attributeKey : AttributeKey) : string {
         return toTitleCase(word);
     }).join(" ");
 }
-

--- a/src/duckling/entitysystem/services/attribute-default-augmentation.service.ts
+++ b/src/duckling/entitysystem/services/attribute-default-augmentation.service.ts
@@ -1,0 +1,66 @@
+import {Component, Injectable} from '@angular/core';
+import {BaseAttributeService} from '../base-attribute.service';
+import {Attribute, AttributeKey, Entity} from '../entity';
+import {Box2, boxUnion} from '../../math';
+import { EntityBoxService, EntityKey, TaggedEntity, EntitySystemService } from '../index';
+import { immutableAssign } from '../../util/index';
+import { MergeKey } from '../../state/index';
+
+export type AugmentedServices = {
+    boxService? : EntityBoxService
+}
+
+/**
+ * If further augmentation to the default entity is required on initialization then
+ * implement this function. If a necessary service isn't passed in via 'services' it
+ * will need to be added here and when the AttributeDefaultService calls this
+ * function.
+ * 
+ * Example: When the collision attribute is created, it should default to whatever the
+ *          current bounding box of the entity is.
+ */
+export type AttributeDefaultAugmentation = (
+    taggedEntity : TaggedEntity, 
+    defaultAttribute : Attribute, 
+    services?: AugmentedServices) => Attribute;
+
+/**
+ * The AttributeDefault service is used to create new entities and attributes.
+ */
+@Injectable()
+export class AttributeDefaultAugmentationService extends BaseAttributeService<AttributeDefaultAugmentation> {
+
+    constructor(private _entityBoxService : EntityBoxService) {
+        super();
+    }
+
+    augmentEntity(taggedEntity : TaggedEntity) : Entity {
+        let patch : Entity = {};
+
+        for (let key in taggedEntity.entity) {
+            patch[key] = this.augmentAttribute(key, taggedEntity);
+        };
+
+        return immutableAssign(taggedEntity.entity, patch);
+    }
+
+    augmentAttribute(key : AttributeKey, taggedEntity : TaggedEntity) : Attribute {
+        let impl = this.getImplementation(key);
+        return this._getDefaultFromImplementation(impl, key, taggedEntity);
+    }
+
+    private _getDefaultFromImplementation(implementation : AttributeDefaultAugmentation, attributeKey : AttributeKey, taggedEntity : TaggedEntity) : Attribute {
+        let patch = immutableAssign(taggedEntity.entity[attributeKey], {});
+        if (implementation) {
+            patch = implementation(
+                taggedEntity,
+                taggedEntity.entity[attributeKey],
+                {
+                    boxService: this._entityBoxService
+                }
+            );
+        }
+        return patch;
+    }
+}
+

--- a/src/duckling/game/collision/collision-attribute.ts
+++ b/src/duckling/game/collision/collision-attribute.ts
@@ -2,6 +2,9 @@ import {Attribute, Entity} from '../../entitysystem/entity';
 import {Vector} from '../../math/vector';
 import {Box2} from '../../math/box2';
 import {SelectOption, toSelectOptions} from '../../controls';
+import { immutableAssign } from '../../util/index';
+import { AugmentedServices } from '../../entitysystem/services/attribute-default-augmentation.service';
+import { TaggedEntity } from '../../entitysystem/index';
 
 export const COLLISION_KEY = "collision";
 
@@ -41,8 +44,8 @@ export interface CollisionAttribute extends Attribute {
 export let defaultCollision : CollisionAttribute = {
     dimension: {
         dimension: {
-            x: 10,
-            y: 10
+            x: 32,
+            y: 32
         },
         position: {
             x: 0,
@@ -58,8 +61,16 @@ export let defaultCollision : CollisionAttribute = {
     },
     anchor: {
         x: 0,
-        y: 0    
+        y: 0
     }
+}
+
+export function defaultCollisionAugmentation(taggedEntity : TaggedEntity, defaultAttribute : CollisionAttribute, services : AugmentedServices) : CollisionAttribute {
+    let boundingBox = services.boxService.getEntityBox(taggedEntity.key);
+    if (boundingBox) {
+        defaultAttribute = {...defaultAttribute, dimension: {...defaultAttribute.dimension, dimension: boundingBox.dimension}};
+    }
+    return defaultAttribute;
 }
 
 /**

--- a/src/duckling/game/drawable/drawable-attribute.ts
+++ b/src/duckling/game/drawable/drawable-attribute.ts
@@ -1,7 +1,11 @@
-import {Attribute, Entity, TaggedEntity} from '../../entitysystem/entity';
-import {immutableAssign} from '../../util';
+import { Attribute, Entity, TaggedEntity } from '../../entitysystem/entity';
+import { immutableAssign } from '../../util';
 
-import {Drawable, defaultDrawable} from './drawable';
+import { Drawable } from './drawable';
+import { defaultContainerDrawable } from './container-drawable';
+import { defaultShapeDrawable } from './shape-drawable';
+import { defaultShape } from './shape';
+import { defaultRectangle } from './rectangle';
 
 export const DRAWABLE_KEY = "drawable";
 
@@ -18,9 +22,21 @@ export interface DrawableAttribute extends Attribute {
 }
 
 export let defaultDrawableAttribute : DrawableAttribute = immutableAssign({}, {
-    topDrawable: defaultDrawable,
+    topDrawable: _defaultTopDrawable(),
     camEntity: ""
 }) as DrawableAttribute;
+
+function _defaultTopDrawable() : Drawable {
+    let innerShape = immutableAssign(defaultRectangle, {});
+    let innerShapeDrawable = immutableAssign(defaultShapeDrawable, { 
+        key: "ShapeDrawable1",
+        shape: innerShape 
+    });
+    return immutableAssign(defaultContainerDrawable, { 
+        key: "TopDrawable",
+        drawables: [innerShapeDrawable] 
+    });
+}
 
 /**
  * Retrieve the drawable attribute from the entity.

--- a/src/duckling/game/drawable/rectangle.ts
+++ b/src/duckling/game/drawable/rectangle.ts
@@ -10,7 +10,7 @@ export interface Rectangle extends Shape {
 export let defaultRectangle : Rectangle = immutableAssign(defaultShape as Rectangle, {
     __cpp_type: "sf::RectangleShape",
     dimension: {
-        x: 10,
-        y: 10
+        x: 32,
+        y: 32
     }
 });

--- a/src/duckling/game/drawable/shape.ts
+++ b/src/duckling/game/drawable/shape.ts
@@ -31,9 +31,9 @@ export interface Shape {
 export let defaultShape : Shape = {
     __cpp_type: "",
     fillColor: {
-        r: 0,
-        g: 0,
-        b: 0,
+        r: 67,
+        g: 154,
+        b: 202,
         a: 255
     }
 };

--- a/src/duckling/game/game.module.ts
+++ b/src/duckling/game/game.module.ts
@@ -49,6 +49,7 @@ import {RequiredAssetService} from '../project';
 import {ProjectLifecycleService} from '../project/project-lifecycle.service';
 
 import {bootstrapGameComponents} from './index';
+import { AttributeDefaultAugmentationService } from '../entitysystem/services/attribute-default-augmentation.service';
 
 const ATTRIBUTE_COMPONENTS = [
     ActionComponent,
@@ -102,6 +103,7 @@ const ATTRIBUTE_COMPONENTS = [
 })
 export class GameModule {
     constructor(public attributeDefaultService : AttributeDefaultService,
+                public attributeDefaultAugmentationService : AttributeDefaultAugmentationService,
                 public entityPositionService : EntityPositionService,
                 public entityBoxService : EntityBoxService,
                 public attributeComponentService : AttributeComponentService,

--- a/src/duckling/game/index.ts
+++ b/src/duckling/game/index.ts
@@ -15,7 +15,7 @@ import {ButtonComponent} from './button/button.component';
 import {defaultPosition, POSITION_KEY} from './position/position-attribute';
 import {setPosition} from './position/set-position';
 import {getPosition} from './position/get-position';
-import {defaultCollision, COLLISION_KEY} from './collision/collision-attribute';
+import {defaultCollision, COLLISION_KEY, defaultCollisionAugmentation} from './collision/collision-attribute';
 import {PositionComponent} from './position/position.component';
 import {CollisionComponent} from './collision/collision.component';
 import {getCollisionAttributeDrawnConstruct} from './collision/collision-drawer';
@@ -55,9 +55,11 @@ import {entityRequiredSoundAssets} from './audio/sound-required-assets';
 import {SoundAttributeComponent} from './audio/sound-attribute.component';
 
 import {JsonComponent} from '../controls/json.component';
+import { AttributeDefaultAugmentationService } from '../entitysystem/services/attribute-default-augmentation.service';
 
 type Services = {
     attributeDefaultService : AttributeDefaultService;
+    attributeDefaultAugmentationService : AttributeDefaultAugmentationService;
     entityPositionService : EntityPositionService,
     entityBoxService: EntityBoxService,
     attributeComponentService: AttributeComponentService,
@@ -103,6 +105,7 @@ function _bootstrapCollisionAttribute(services : Services) {
     services.entityDrawerService.register(COLLISION_KEY, getCollisionAttributeDrawnConstruct);
     services.entityBoxService.register(COLLISION_KEY, collisionBoundingBox);
     services.attributeDefaultService.register(COLLISION_KEY, {createByDefault: true, default: defaultCollision});
+    services.attributeDefaultAugmentationService.register(COLLISION_KEY, defaultCollisionAugmentation);
 }
 
 function _bootstrapCameraAttribute(services : Services) {

--- a/src/duckling/state/undo-redo.ts
+++ b/src/duckling/state/undo-redo.ts
@@ -7,12 +7,13 @@ export const UNDO_ACTION = "UndoRedo.Undo";
 export const REDO_ACTION = "UndoRedo.Redo";
 export const CLEAR_HISTORY_ACTION = "UndoRedo.Clear";
 
+export type MergeKey = number;
 let key = 1;
 /**
  * Create a new unique merge key.
  * @return A merge key that can be used to merge actions.
  */
-export function newMergeKey() {
+export function newMergeKey() : MergeKey {
     return key++;
 }
 


### PR DESCRIPTION
Resolves #347, #357, #358 

* Create the drawable attribute as a container drawable
* Set the size of the collision box to the entity's bounding box when created